### PR TITLE
Updated to new cassandra thrift and a few other improvements

### DIFF
--- a/libcassandra/cassandra.cc
+++ b/libcassandra/cassandra.cc
@@ -126,7 +126,9 @@ void Cassandra::insertColumn(const string& key,
   Column col;
   col.name.assign(column_name);
   col.value.assign(value);
-  col.timestamp= createTimestamp();
+  col.__isset.value = true;
+  col.timestamp = createTimestamp();
+  col.__isset.timestamp = true;
   if (ttl) 
   {
     col.ttl=ttl;

--- a/libcassandra/cassandra.cc
+++ b/libcassandra/cassandra.cc
@@ -345,6 +345,9 @@ vector<Column> Cassandra::getSliceNames(const string& key,
   return result;
 }
 
+void Cassandra::truncate(const string& cf_name) {
+  thrift_client->truncate(cf_name);
+}
 
 vector<Column> Cassandra::getSliceNames(const string& key,
                                         const ColumnParent& col_parent,

--- a/libcassandra/cassandra.cc
+++ b/libcassandra/cassandra.cc
@@ -536,7 +536,6 @@ vector<KeyspaceDefinition> Cassandra::getKeyspaces()
       KeyspaceDefinition entry(thrift_entry.name,
                                thrift_entry.strategy_class,
                                thrift_entry.strategy_options,
-                               thrift_entry.replication_factor,
                                thrift_entry.cf_defs);
       key_spaces.push_back(entry);
     }

--- a/libcassandra/cassandra.h
+++ b/libcassandra/cassandra.h
@@ -296,6 +296,12 @@ public:
                                                      const std::string& column_family,
                                                      const std::string& super_column_name);
 
+  /**
+   * Truncate a column family
+   * @param[in] cf_name Column family name
+   */
+  void truncate(const std::string& cf_name);
+
   std::vector<org::apache::cassandra::Column> getSliceNames(const std::string& key,
                                                             const org::apache::cassandra::ColumnParent& col_parent,
                                                             org::apache::cassandra::SlicePredicate& pred,

--- a/libcassandra/cassandra_factory.cc
+++ b/libcassandra/cassandra_factory.cc
@@ -15,6 +15,8 @@
 #include <transport/TSocket.h>
 #include <transport/TTransportUtils.h>
 
+#include <boost/shared_ptr.hpp>
+
 #include "libgenthrift/Cassandra.h"
 
 #include "libcassandra/cassandra.h"
@@ -63,18 +65,18 @@ CassandraFactory::CassandraFactory(const string& in_host, int in_port)
 CassandraFactory::~CassandraFactory() {}
 
 
-tr1::shared_ptr<Cassandra> CassandraFactory::create()
+boost::shared_ptr<Cassandra> CassandraFactory::create()
 {
   CassandraClient *thrift_client= createThriftClient(host, port);
-  tr1::shared_ptr<Cassandra> ret(new Cassandra(thrift_client, host, port));
+  boost::shared_ptr<Cassandra> ret(new Cassandra(thrift_client, host, port));
   return ret;
 }
 
 
-tr1::shared_ptr<Cassandra> CassandraFactory::create(const string& keyspace)
+boost::shared_ptr<Cassandra> CassandraFactory::create(const string& keyspace)
 {
   CassandraClient *thrift_client= createThriftClient(host, port);
-  tr1::shared_ptr<Cassandra> ret(new Cassandra(thrift_client, host, port, keyspace));
+  boost::shared_ptr<Cassandra> ret(new Cassandra(thrift_client, host, port, keyspace));
   return ret;
 }
 

--- a/libcassandra/cassandra_factory.h
+++ b/libcassandra/cassandra_factory.h
@@ -12,7 +12,8 @@
 
 #include <string>
 #include <vector>
-#include <tr1/memory>
+
+#include <boost/shared_ptr.hpp>
 
 namespace org 
 { 
@@ -44,13 +45,13 @@ public:
   /**
    * @return a shared ptr which points to a Cassandra client
    */
-  std::tr1::shared_ptr<Cassandra> create();
+  boost::shared_ptr<Cassandra> create();
 
   /**
    * @param[in] keyspace name of keyspace to associate this instance with
    * @return a shared ptr which points to a Cassandra client
    */
-  std::tr1::shared_ptr<Cassandra> create(const std::string& keyspace);
+  boost::shared_ptr<Cassandra> create(const std::string& keyspace);
 
   /**
    * @return port number associated with cassandra instances created

--- a/libcassandra/keyspace_definition.cc
+++ b/libcassandra/keyspace_definition.cc
@@ -100,7 +100,7 @@ map<string, string> KeyspaceDefinition::getStrategyOptions() const
 
 void KeyspaceDefinition::setStrategyOptions(const map<string, string>& opts)
 {
-  (void) opts;
+  strategy_options.insert(opts.begin(), opts.end());
 }
 
 

--- a/libcassandra/keyspace_definition.cc
+++ b/libcassandra/keyspace_definition.cc
@@ -24,7 +24,6 @@ KeyspaceDefinition::KeyspaceDefinition()
     name(),
     strategy_class("org.apache.cassandra.locator.SimpleStrategy"),
     strategy_options(),
-    replication_factor(1),
     col_family_defs()
 {}
 
@@ -32,13 +31,11 @@ KeyspaceDefinition::KeyspaceDefinition()
 KeyspaceDefinition::KeyspaceDefinition(const string& in_name,
                                        const string& in_strategy_class,
                                        const map<string, string>& in_strategy_options,
-                                       const int32_t in_replication_factor,
                                        vector<CfDef>& in_cf_defs)
   :
     name(in_name),
     strategy_class(in_strategy_class),
     strategy_options(in_strategy_options),
-    replication_factor(in_replication_factor),
     col_family_defs()
 {
   for (vector<CfDef>::iterator it= in_cf_defs.begin();
@@ -104,18 +101,6 @@ map<string, string> KeyspaceDefinition::getStrategyOptions() const
 void KeyspaceDefinition::setStrategyOptions(const map<string, string>& opts)
 {
   (void) opts;
-}
-
-
-int32_t KeyspaceDefinition::getReplicationFactor() const
-{
-  return replication_factor;
-}
-
-
-void KeyspaceDefinition::setReplicationFactor(int32_t rep_factor)
-{
-  replication_factor= rep_factor;
 }
 
 

--- a/libcassandra/keyspace_definition.h
+++ b/libcassandra/keyspace_definition.h
@@ -32,7 +32,6 @@ public:
   KeyspaceDefinition(const std::string& in_name,
                      const std::string& in_strategy_class,
                      const std::map<std::string, std::string>& in_strategy_options,
-                     const int32_t in_replication_factor,
                      std::vector<org::apache::cassandra::CfDef>& in_cf_defs);
   ~KeyspaceDefinition() {}
 
@@ -56,13 +55,6 @@ public:
   std::map<std::string, std::string> getStrategyOptions() const;
 
   void setStrategyOptions(const std::map<std::string, std::string>& opts);
-
-  /**
-   * @return replication factor for this keyspace
-   */
-  int32_t getReplicationFactor() const;
-
-  void setReplicationFactor(int32_t rep_factor);
 
   /**
    * @return the column families in this keyspace

--- a/libcassandra/util_functions.cc
+++ b/libcassandra/util_functions.cc
@@ -71,6 +71,12 @@ KsDef createKsDefObject(const KeyspaceDefinition& ks_def)
   KsDef thrift_ks_def;
   thrift_ks_def.name.assign(ks_def.getName());
   thrift_ks_def.strategy_class.assign(ks_def.getStrategyClass());
+  if (!ks_def.getStrategyOptions().empty()) {
+    thrift_ks_def.__isset.strategy_options = true;
+    const map<string, string>& strategy_options = ks_def.getStrategyOptions();
+    thrift_ks_def.strategy_options.insert(strategy_options.begin(),
+                                          strategy_options.end());
+  }
   vector<ColumnFamilyDefinition> cf_defs= ks_def.getColumnFamilies();
   for (vector<ColumnFamilyDefinition>::iterator it= cf_defs.begin();
        it != cf_defs.end();

--- a/libcassandra/util_functions.cc
+++ b/libcassandra/util_functions.cc
@@ -79,7 +79,6 @@ KsDef createKsDefObject(const KeyspaceDefinition& ks_def)
     CfDef entry= createCfDefObject(*it);
     thrift_ks_def.cf_defs.push_back(entry);
   }
-  thrift_ks_def.replication_factor= ks_def.getReplicationFactor();
   return thrift_ks_def;
 }
 

--- a/libgenthrift/Cassandra.cpp
+++ b/libgenthrift/Cassandra.cpp
@@ -390,9 +390,9 @@ uint32_t Cassandra_get_args::read(::apache::thrift::protocol::TProtocol* iprot) 
         break;
       case 3:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast60;
-          xfer += iprot->readI32(ecast60);
-          this->consistency_level = (ConsistencyLevel::type)ecast60;
+          int32_t ecast79;
+          xfer += iprot->readI32(ecast79);
+          this->consistency_level = (ConsistencyLevel::type)ecast79;
           isset_consistency_level = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -676,9 +676,9 @@ uint32_t Cassandra_get_slice_args::read(::apache::thrift::protocol::TProtocol* i
         break;
       case 4:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast61;
-          xfer += iprot->readI32(ecast61);
-          this->consistency_level = (ConsistencyLevel::type)ecast61;
+          int32_t ecast80;
+          xfer += iprot->readI32(ecast80);
+          this->consistency_level = (ConsistencyLevel::type)ecast80;
           isset_consistency_level = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -768,14 +768,14 @@ uint32_t Cassandra_get_slice_result::read(::apache::thrift::protocol::TProtocol*
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size62;
-            ::apache::thrift::protocol::TType _etype65;
-            iprot->readListBegin(_etype65, _size62);
-            this->success.resize(_size62);
-            uint32_t _i66;
-            for (_i66 = 0; _i66 < _size62; ++_i66)
+            uint32_t _size81;
+            ::apache::thrift::protocol::TType _etype84;
+            iprot->readListBegin(_etype84, _size81);
+            this->success.resize(_size81);
+            uint32_t _i85;
+            for (_i85 = 0; _i85 < _size81; ++_i85)
             {
-              xfer += this->success[_i66].read(iprot);
+              xfer += this->success[_i85].read(iprot);
             }
             iprot->readListEnd();
           }
@@ -830,10 +830,10 @@ uint32_t Cassandra_get_slice_result::write(::apache::thrift::protocol::TProtocol
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, this->success.size());
-      std::vector<ColumnOrSuperColumn> ::const_iterator _iter67;
-      for (_iter67 = this->success.begin(); _iter67 != this->success.end(); ++_iter67)
+      std::vector<ColumnOrSuperColumn> ::const_iterator _iter86;
+      for (_iter86 = this->success.begin(); _iter86 != this->success.end(); ++_iter86)
       {
-        xfer += (*_iter67).write(oprot);
+        xfer += (*_iter86).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -880,14 +880,14 @@ uint32_t Cassandra_get_slice_presult::read(::apache::thrift::protocol::TProtocol
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size68;
-            ::apache::thrift::protocol::TType _etype71;
-            iprot->readListBegin(_etype71, _size68);
-            (*(this->success)).resize(_size68);
-            uint32_t _i72;
-            for (_i72 = 0; _i72 < _size68; ++_i72)
+            uint32_t _size87;
+            ::apache::thrift::protocol::TType _etype90;
+            iprot->readListBegin(_etype90, _size87);
+            (*(this->success)).resize(_size87);
+            uint32_t _i91;
+            for (_i91 = 0; _i91 < _size87; ++_i91)
             {
-              xfer += (*(this->success))[_i72].read(iprot);
+              xfer += (*(this->success))[_i91].read(iprot);
             }
             iprot->readListEnd();
           }
@@ -982,9 +982,9 @@ uint32_t Cassandra_get_count_args::read(::apache::thrift::protocol::TProtocol* i
         break;
       case 4:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast73;
-          xfer += iprot->readI32(ecast73);
-          this->consistency_level = (ConsistencyLevel::type)ecast73;
+          int32_t ecast92;
+          xfer += iprot->readI32(ecast92);
+          this->consistency_level = (ConsistencyLevel::type)ecast92;
           isset_consistency_level = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -1234,14 +1234,14 @@ uint32_t Cassandra_multiget_slice_args::read(::apache::thrift::protocol::TProtoc
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->keys.clear();
-            uint32_t _size74;
-            ::apache::thrift::protocol::TType _etype77;
-            iprot->readListBegin(_etype77, _size74);
-            this->keys.resize(_size74);
-            uint32_t _i78;
-            for (_i78 = 0; _i78 < _size74; ++_i78)
+            uint32_t _size93;
+            ::apache::thrift::protocol::TType _etype96;
+            iprot->readListBegin(_etype96, _size93);
+            this->keys.resize(_size93);
+            uint32_t _i97;
+            for (_i97 = 0; _i97 < _size93; ++_i97)
             {
-              xfer += iprot->readBinary(this->keys[_i78]);
+              xfer += iprot->readBinary(this->keys[_i97]);
             }
             iprot->readListEnd();
           }
@@ -1268,9 +1268,9 @@ uint32_t Cassandra_multiget_slice_args::read(::apache::thrift::protocol::TProtoc
         break;
       case 4:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast79;
-          xfer += iprot->readI32(ecast79);
-          this->consistency_level = (ConsistencyLevel::type)ecast79;
+          int32_t ecast98;
+          xfer += iprot->readI32(ecast98);
+          this->consistency_level = (ConsistencyLevel::type)ecast98;
           isset_consistency_level = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -1302,10 +1302,10 @@ uint32_t Cassandra_multiget_slice_args::write(::apache::thrift::protocol::TProto
   xfer += oprot->writeFieldBegin("keys", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, this->keys.size());
-    std::vector<std::string> ::const_iterator _iter80;
-    for (_iter80 = this->keys.begin(); _iter80 != this->keys.end(); ++_iter80)
+    std::vector<std::string> ::const_iterator _iter99;
+    for (_iter99 = this->keys.begin(); _iter99 != this->keys.end(); ++_iter99)
     {
-      xfer += oprot->writeBinary((*_iter80));
+      xfer += oprot->writeBinary((*_iter99));
     }
     xfer += oprot->writeListEnd();
   }
@@ -1330,10 +1330,10 @@ uint32_t Cassandra_multiget_slice_pargs::write(::apache::thrift::protocol::TProt
   xfer += oprot->writeFieldBegin("keys", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, (*(this->keys)).size());
-    std::vector<std::string> ::const_iterator _iter81;
-    for (_iter81 = (*(this->keys)).begin(); _iter81 != (*(this->keys)).end(); ++_iter81)
+    std::vector<std::string> ::const_iterator _iter100;
+    for (_iter100 = (*(this->keys)).begin(); _iter100 != (*(this->keys)).end(); ++_iter100)
     {
-      xfer += oprot->writeBinary((*_iter81));
+      xfer += oprot->writeBinary((*_iter100));
     }
     xfer += oprot->writeListEnd();
   }
@@ -1376,26 +1376,26 @@ uint32_t Cassandra_multiget_slice_result::read(::apache::thrift::protocol::TProt
         if (ftype == ::apache::thrift::protocol::T_MAP) {
           {
             this->success.clear();
-            uint32_t _size82;
-            ::apache::thrift::protocol::TType _ktype83;
-            ::apache::thrift::protocol::TType _vtype84;
-            iprot->readMapBegin(_ktype83, _vtype84, _size82);
-            uint32_t _i86;
-            for (_i86 = 0; _i86 < _size82; ++_i86)
+            uint32_t _size101;
+            ::apache::thrift::protocol::TType _ktype102;
+            ::apache::thrift::protocol::TType _vtype103;
+            iprot->readMapBegin(_ktype102, _vtype103, _size101);
+            uint32_t _i105;
+            for (_i105 = 0; _i105 < _size101; ++_i105)
             {
-              std::string _key87;
-              xfer += iprot->readBinary(_key87);
-              std::vector<ColumnOrSuperColumn> & _val88 = this->success[_key87];
+              std::string _key106;
+              xfer += iprot->readBinary(_key106);
+              std::vector<ColumnOrSuperColumn> & _val107 = this->success[_key106];
               {
-                _val88.clear();
-                uint32_t _size89;
-                ::apache::thrift::protocol::TType _etype92;
-                iprot->readListBegin(_etype92, _size89);
-                _val88.resize(_size89);
-                uint32_t _i93;
-                for (_i93 = 0; _i93 < _size89; ++_i93)
+                _val107.clear();
+                uint32_t _size108;
+                ::apache::thrift::protocol::TType _etype111;
+                iprot->readListBegin(_etype111, _size108);
+                _val107.resize(_size108);
+                uint32_t _i112;
+                for (_i112 = 0; _i112 < _size108; ++_i112)
                 {
-                  xfer += _val88[_i93].read(iprot);
+                  xfer += _val107[_i112].read(iprot);
                 }
                 iprot->readListEnd();
               }
@@ -1453,16 +1453,16 @@ uint32_t Cassandra_multiget_slice_result::write(::apache::thrift::protocol::TPro
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_MAP, 0);
     {
       xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_STRING, ::apache::thrift::protocol::T_LIST, this->success.size());
-      std::map<std::string, std::vector<ColumnOrSuperColumn> > ::const_iterator _iter94;
-      for (_iter94 = this->success.begin(); _iter94 != this->success.end(); ++_iter94)
+      std::map<std::string, std::vector<ColumnOrSuperColumn> > ::const_iterator _iter113;
+      for (_iter113 = this->success.begin(); _iter113 != this->success.end(); ++_iter113)
       {
-        xfer += oprot->writeBinary(_iter94->first);
+        xfer += oprot->writeBinary(_iter113->first);
         {
-          xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, _iter94->second.size());
-          std::vector<ColumnOrSuperColumn> ::const_iterator _iter95;
-          for (_iter95 = _iter94->second.begin(); _iter95 != _iter94->second.end(); ++_iter95)
+          xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, _iter113->second.size());
+          std::vector<ColumnOrSuperColumn> ::const_iterator _iter114;
+          for (_iter114 = _iter113->second.begin(); _iter114 != _iter113->second.end(); ++_iter114)
           {
-            xfer += (*_iter95).write(oprot);
+            xfer += (*_iter114).write(oprot);
           }
           xfer += oprot->writeListEnd();
         }
@@ -1512,26 +1512,26 @@ uint32_t Cassandra_multiget_slice_presult::read(::apache::thrift::protocol::TPro
         if (ftype == ::apache::thrift::protocol::T_MAP) {
           {
             (*(this->success)).clear();
-            uint32_t _size96;
-            ::apache::thrift::protocol::TType _ktype97;
-            ::apache::thrift::protocol::TType _vtype98;
-            iprot->readMapBegin(_ktype97, _vtype98, _size96);
-            uint32_t _i100;
-            for (_i100 = 0; _i100 < _size96; ++_i100)
+            uint32_t _size115;
+            ::apache::thrift::protocol::TType _ktype116;
+            ::apache::thrift::protocol::TType _vtype117;
+            iprot->readMapBegin(_ktype116, _vtype117, _size115);
+            uint32_t _i119;
+            for (_i119 = 0; _i119 < _size115; ++_i119)
             {
-              std::string _key101;
-              xfer += iprot->readBinary(_key101);
-              std::vector<ColumnOrSuperColumn> & _val102 = (*(this->success))[_key101];
+              std::string _key120;
+              xfer += iprot->readBinary(_key120);
+              std::vector<ColumnOrSuperColumn> & _val121 = (*(this->success))[_key120];
               {
-                _val102.clear();
-                uint32_t _size103;
-                ::apache::thrift::protocol::TType _etype106;
-                iprot->readListBegin(_etype106, _size103);
-                _val102.resize(_size103);
-                uint32_t _i107;
-                for (_i107 = 0; _i107 < _size103; ++_i107)
+                _val121.clear();
+                uint32_t _size122;
+                ::apache::thrift::protocol::TType _etype125;
+                iprot->readListBegin(_etype125, _size122);
+                _val121.resize(_size122);
+                uint32_t _i126;
+                for (_i126 = 0; _i126 < _size122; ++_i126)
                 {
-                  xfer += _val102[_i107].read(iprot);
+                  xfer += _val121[_i126].read(iprot);
                 }
                 iprot->readListEnd();
               }
@@ -1607,14 +1607,14 @@ uint32_t Cassandra_multiget_count_args::read(::apache::thrift::protocol::TProtoc
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->keys.clear();
-            uint32_t _size108;
-            ::apache::thrift::protocol::TType _etype111;
-            iprot->readListBegin(_etype111, _size108);
-            this->keys.resize(_size108);
-            uint32_t _i112;
-            for (_i112 = 0; _i112 < _size108; ++_i112)
+            uint32_t _size127;
+            ::apache::thrift::protocol::TType _etype130;
+            iprot->readListBegin(_etype130, _size127);
+            this->keys.resize(_size127);
+            uint32_t _i131;
+            for (_i131 = 0; _i131 < _size127; ++_i131)
             {
-              xfer += iprot->readBinary(this->keys[_i112]);
+              xfer += iprot->readBinary(this->keys[_i131]);
             }
             iprot->readListEnd();
           }
@@ -1641,9 +1641,9 @@ uint32_t Cassandra_multiget_count_args::read(::apache::thrift::protocol::TProtoc
         break;
       case 4:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast113;
-          xfer += iprot->readI32(ecast113);
-          this->consistency_level = (ConsistencyLevel::type)ecast113;
+          int32_t ecast132;
+          xfer += iprot->readI32(ecast132);
+          this->consistency_level = (ConsistencyLevel::type)ecast132;
           isset_consistency_level = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -1675,10 +1675,10 @@ uint32_t Cassandra_multiget_count_args::write(::apache::thrift::protocol::TProto
   xfer += oprot->writeFieldBegin("keys", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, this->keys.size());
-    std::vector<std::string> ::const_iterator _iter114;
-    for (_iter114 = this->keys.begin(); _iter114 != this->keys.end(); ++_iter114)
+    std::vector<std::string> ::const_iterator _iter133;
+    for (_iter133 = this->keys.begin(); _iter133 != this->keys.end(); ++_iter133)
     {
-      xfer += oprot->writeBinary((*_iter114));
+      xfer += oprot->writeBinary((*_iter133));
     }
     xfer += oprot->writeListEnd();
   }
@@ -1703,10 +1703,10 @@ uint32_t Cassandra_multiget_count_pargs::write(::apache::thrift::protocol::TProt
   xfer += oprot->writeFieldBegin("keys", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, (*(this->keys)).size());
-    std::vector<std::string> ::const_iterator _iter115;
-    for (_iter115 = (*(this->keys)).begin(); _iter115 != (*(this->keys)).end(); ++_iter115)
+    std::vector<std::string> ::const_iterator _iter134;
+    for (_iter134 = (*(this->keys)).begin(); _iter134 != (*(this->keys)).end(); ++_iter134)
     {
-      xfer += oprot->writeBinary((*_iter115));
+      xfer += oprot->writeBinary((*_iter134));
     }
     xfer += oprot->writeListEnd();
   }
@@ -1749,17 +1749,17 @@ uint32_t Cassandra_multiget_count_result::read(::apache::thrift::protocol::TProt
         if (ftype == ::apache::thrift::protocol::T_MAP) {
           {
             this->success.clear();
-            uint32_t _size116;
-            ::apache::thrift::protocol::TType _ktype117;
-            ::apache::thrift::protocol::TType _vtype118;
-            iprot->readMapBegin(_ktype117, _vtype118, _size116);
-            uint32_t _i120;
-            for (_i120 = 0; _i120 < _size116; ++_i120)
+            uint32_t _size135;
+            ::apache::thrift::protocol::TType _ktype136;
+            ::apache::thrift::protocol::TType _vtype137;
+            iprot->readMapBegin(_ktype136, _vtype137, _size135);
+            uint32_t _i139;
+            for (_i139 = 0; _i139 < _size135; ++_i139)
             {
-              std::string _key121;
-              xfer += iprot->readBinary(_key121);
-              int32_t& _val122 = this->success[_key121];
-              xfer += iprot->readI32(_val122);
+              std::string _key140;
+              xfer += iprot->readBinary(_key140);
+              int32_t& _val141 = this->success[_key140];
+              xfer += iprot->readI32(_val141);
             }
             iprot->readMapEnd();
           }
@@ -1814,11 +1814,11 @@ uint32_t Cassandra_multiget_count_result::write(::apache::thrift::protocol::TPro
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_MAP, 0);
     {
       xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_STRING, ::apache::thrift::protocol::T_I32, this->success.size());
-      std::map<std::string, int32_t> ::const_iterator _iter123;
-      for (_iter123 = this->success.begin(); _iter123 != this->success.end(); ++_iter123)
+      std::map<std::string, int32_t> ::const_iterator _iter142;
+      for (_iter142 = this->success.begin(); _iter142 != this->success.end(); ++_iter142)
       {
-        xfer += oprot->writeBinary(_iter123->first);
-        xfer += oprot->writeI32(_iter123->second);
+        xfer += oprot->writeBinary(_iter142->first);
+        xfer += oprot->writeI32(_iter142->second);
       }
       xfer += oprot->writeMapEnd();
     }
@@ -1865,17 +1865,17 @@ uint32_t Cassandra_multiget_count_presult::read(::apache::thrift::protocol::TPro
         if (ftype == ::apache::thrift::protocol::T_MAP) {
           {
             (*(this->success)).clear();
-            uint32_t _size124;
-            ::apache::thrift::protocol::TType _ktype125;
-            ::apache::thrift::protocol::TType _vtype126;
-            iprot->readMapBegin(_ktype125, _vtype126, _size124);
-            uint32_t _i128;
-            for (_i128 = 0; _i128 < _size124; ++_i128)
+            uint32_t _size143;
+            ::apache::thrift::protocol::TType _ktype144;
+            ::apache::thrift::protocol::TType _vtype145;
+            iprot->readMapBegin(_ktype144, _vtype145, _size143);
+            uint32_t _i147;
+            for (_i147 = 0; _i147 < _size143; ++_i147)
             {
-              std::string _key129;
-              xfer += iprot->readBinary(_key129);
-              int32_t& _val130 = (*(this->success))[_key129];
-              xfer += iprot->readI32(_val130);
+              std::string _key148;
+              xfer += iprot->readBinary(_key148);
+              int32_t& _val149 = (*(this->success))[_key148];
+              xfer += iprot->readI32(_val149);
             }
             iprot->readMapEnd();
           }
@@ -1970,9 +1970,9 @@ uint32_t Cassandra_get_range_slices_args::read(::apache::thrift::protocol::TProt
         break;
       case 4:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast131;
-          xfer += iprot->readI32(ecast131);
-          this->consistency_level = (ConsistencyLevel::type)ecast131;
+          int32_t ecast150;
+          xfer += iprot->readI32(ecast150);
+          this->consistency_level = (ConsistencyLevel::type)ecast150;
           isset_consistency_level = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -2062,14 +2062,14 @@ uint32_t Cassandra_get_range_slices_result::read(::apache::thrift::protocol::TPr
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size132;
-            ::apache::thrift::protocol::TType _etype135;
-            iprot->readListBegin(_etype135, _size132);
-            this->success.resize(_size132);
-            uint32_t _i136;
-            for (_i136 = 0; _i136 < _size132; ++_i136)
+            uint32_t _size151;
+            ::apache::thrift::protocol::TType _etype154;
+            iprot->readListBegin(_etype154, _size151);
+            this->success.resize(_size151);
+            uint32_t _i155;
+            for (_i155 = 0; _i155 < _size151; ++_i155)
             {
-              xfer += this->success[_i136].read(iprot);
+              xfer += this->success[_i155].read(iprot);
             }
             iprot->readListEnd();
           }
@@ -2124,10 +2124,10 @@ uint32_t Cassandra_get_range_slices_result::write(::apache::thrift::protocol::TP
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, this->success.size());
-      std::vector<KeySlice> ::const_iterator _iter137;
-      for (_iter137 = this->success.begin(); _iter137 != this->success.end(); ++_iter137)
+      std::vector<KeySlice> ::const_iterator _iter156;
+      for (_iter156 = this->success.begin(); _iter156 != this->success.end(); ++_iter156)
       {
-        xfer += (*_iter137).write(oprot);
+        xfer += (*_iter156).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -2174,14 +2174,14 @@ uint32_t Cassandra_get_range_slices_presult::read(::apache::thrift::protocol::TP
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size138;
-            ::apache::thrift::protocol::TType _etype141;
-            iprot->readListBegin(_etype141, _size138);
-            (*(this->success)).resize(_size138);
-            uint32_t _i142;
-            for (_i142 = 0; _i142 < _size138; ++_i142)
+            uint32_t _size157;
+            ::apache::thrift::protocol::TType _etype160;
+            iprot->readListBegin(_etype160, _size157);
+            (*(this->success)).resize(_size157);
+            uint32_t _i161;
+            for (_i161 = 0; _i161 < _size157; ++_i161)
             {
-              xfer += (*(this->success))[_i142].read(iprot);
+              xfer += (*(this->success))[_i161].read(iprot);
             }
             iprot->readListEnd();
           }
@@ -2276,9 +2276,9 @@ uint32_t Cassandra_get_indexed_slices_args::read(::apache::thrift::protocol::TPr
         break;
       case 4:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast143;
-          xfer += iprot->readI32(ecast143);
-          this->consistency_level = (ConsistencyLevel::type)ecast143;
+          int32_t ecast162;
+          xfer += iprot->readI32(ecast162);
+          this->consistency_level = (ConsistencyLevel::type)ecast162;
           isset_consistency_level = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -2368,14 +2368,14 @@ uint32_t Cassandra_get_indexed_slices_result::read(::apache::thrift::protocol::T
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size144;
-            ::apache::thrift::protocol::TType _etype147;
-            iprot->readListBegin(_etype147, _size144);
-            this->success.resize(_size144);
-            uint32_t _i148;
-            for (_i148 = 0; _i148 < _size144; ++_i148)
+            uint32_t _size163;
+            ::apache::thrift::protocol::TType _etype166;
+            iprot->readListBegin(_etype166, _size163);
+            this->success.resize(_size163);
+            uint32_t _i167;
+            for (_i167 = 0; _i167 < _size163; ++_i167)
             {
-              xfer += this->success[_i148].read(iprot);
+              xfer += this->success[_i167].read(iprot);
             }
             iprot->readListEnd();
           }
@@ -2430,10 +2430,10 @@ uint32_t Cassandra_get_indexed_slices_result::write(::apache::thrift::protocol::
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, this->success.size());
-      std::vector<KeySlice> ::const_iterator _iter149;
-      for (_iter149 = this->success.begin(); _iter149 != this->success.end(); ++_iter149)
+      std::vector<KeySlice> ::const_iterator _iter168;
+      for (_iter168 = this->success.begin(); _iter168 != this->success.end(); ++_iter168)
       {
-        xfer += (*_iter149).write(oprot);
+        xfer += (*_iter168).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -2480,14 +2480,14 @@ uint32_t Cassandra_get_indexed_slices_presult::read(::apache::thrift::protocol::
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size150;
-            ::apache::thrift::protocol::TType _etype153;
-            iprot->readListBegin(_etype153, _size150);
-            (*(this->success)).resize(_size150);
-            uint32_t _i154;
-            for (_i154 = 0; _i154 < _size150; ++_i154)
+            uint32_t _size169;
+            ::apache::thrift::protocol::TType _etype172;
+            iprot->readListBegin(_etype172, _size169);
+            (*(this->success)).resize(_size169);
+            uint32_t _i173;
+            for (_i173 = 0; _i173 < _size169; ++_i173)
             {
-              xfer += (*(this->success))[_i154].read(iprot);
+              xfer += (*(this->success))[_i173].read(iprot);
             }
             iprot->readListEnd();
           }
@@ -2582,9 +2582,9 @@ uint32_t Cassandra_insert_args::read(::apache::thrift::protocol::TProtocol* ipro
         break;
       case 4:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast155;
-          xfer += iprot->readI32(ecast155);
-          this->consistency_level = (ConsistencyLevel::type)ecast155;
+          int32_t ecast174;
+          xfer += iprot->readI32(ecast174);
+          this->consistency_level = (ConsistencyLevel::type)ecast174;
           isset_consistency_level = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -2786,6 +2786,260 @@ uint32_t Cassandra_insert_presult::read(::apache::thrift::protocol::TProtocol* i
   return xfer;
 }
 
+uint32_t Cassandra_add_args::read(::apache::thrift::protocol::TProtocol* iprot) {
+
+  uint32_t xfer = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TType ftype;
+  int16_t fid;
+
+  xfer += iprot->readStructBegin(fname);
+
+  using ::apache::thrift::protocol::TProtocolException;
+
+  bool isset_key = false;
+  bool isset_column_parent = false;
+  bool isset_column = false;
+  bool isset_consistency_level = false;
+
+  while (true)
+  {
+    xfer += iprot->readFieldBegin(fname, ftype, fid);
+    if (ftype == ::apache::thrift::protocol::T_STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+        if (ftype == ::apache::thrift::protocol::T_STRING) {
+          xfer += iprot->readBinary(this->key);
+          isset_key = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->column_parent.read(iprot);
+          isset_column_parent = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 3:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->column.read(iprot);
+          isset_column = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 4:
+        if (ftype == ::apache::thrift::protocol::T_I32) {
+          int32_t ecast175;
+          xfer += iprot->readI32(ecast175);
+          this->consistency_level = (ConsistencyLevel::type)ecast175;
+          isset_consistency_level = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      default:
+        xfer += iprot->skip(ftype);
+        break;
+    }
+    xfer += iprot->readFieldEnd();
+  }
+
+  xfer += iprot->readStructEnd();
+
+  if (!isset_key)
+    throw TProtocolException(TProtocolException::INVALID_DATA);
+  if (!isset_column_parent)
+    throw TProtocolException(TProtocolException::INVALID_DATA);
+  if (!isset_column)
+    throw TProtocolException(TProtocolException::INVALID_DATA);
+  if (!isset_consistency_level)
+    throw TProtocolException(TProtocolException::INVALID_DATA);
+  return xfer;
+}
+
+uint32_t Cassandra_add_args::write(::apache::thrift::protocol::TProtocol* oprot) const {
+  uint32_t xfer = 0;
+  xfer += oprot->writeStructBegin("Cassandra_add_args");
+  xfer += oprot->writeFieldBegin("key", ::apache::thrift::protocol::T_STRING, 1);
+  xfer += oprot->writeBinary(this->key);
+  xfer += oprot->writeFieldEnd();
+  xfer += oprot->writeFieldBegin("column_parent", ::apache::thrift::protocol::T_STRUCT, 2);
+  xfer += this->column_parent.write(oprot);
+  xfer += oprot->writeFieldEnd();
+  xfer += oprot->writeFieldBegin("column", ::apache::thrift::protocol::T_STRUCT, 3);
+  xfer += this->column.write(oprot);
+  xfer += oprot->writeFieldEnd();
+  xfer += oprot->writeFieldBegin("consistency_level", ::apache::thrift::protocol::T_I32, 4);
+  xfer += oprot->writeI32((int32_t)this->consistency_level);
+  xfer += oprot->writeFieldEnd();
+  xfer += oprot->writeFieldStop();
+  xfer += oprot->writeStructEnd();
+  return xfer;
+}
+
+uint32_t Cassandra_add_pargs::write(::apache::thrift::protocol::TProtocol* oprot) const {
+  uint32_t xfer = 0;
+  xfer += oprot->writeStructBegin("Cassandra_add_pargs");
+  xfer += oprot->writeFieldBegin("key", ::apache::thrift::protocol::T_STRING, 1);
+  xfer += oprot->writeBinary((*(this->key)));
+  xfer += oprot->writeFieldEnd();
+  xfer += oprot->writeFieldBegin("column_parent", ::apache::thrift::protocol::T_STRUCT, 2);
+  xfer += (*(this->column_parent)).write(oprot);
+  xfer += oprot->writeFieldEnd();
+  xfer += oprot->writeFieldBegin("column", ::apache::thrift::protocol::T_STRUCT, 3);
+  xfer += (*(this->column)).write(oprot);
+  xfer += oprot->writeFieldEnd();
+  xfer += oprot->writeFieldBegin("consistency_level", ::apache::thrift::protocol::T_I32, 4);
+  xfer += oprot->writeI32((int32_t)(*(this->consistency_level)));
+  xfer += oprot->writeFieldEnd();
+  xfer += oprot->writeFieldStop();
+  xfer += oprot->writeStructEnd();
+  return xfer;
+}
+
+uint32_t Cassandra_add_result::read(::apache::thrift::protocol::TProtocol* iprot) {
+
+  uint32_t xfer = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TType ftype;
+  int16_t fid;
+
+  xfer += iprot->readStructBegin(fname);
+
+  using ::apache::thrift::protocol::TProtocolException;
+
+
+  while (true)
+  {
+    xfer += iprot->readFieldBegin(fname, ftype, fid);
+    if (ftype == ::apache::thrift::protocol::T_STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->ire.read(iprot);
+          this->__isset.ire = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->ue.read(iprot);
+          this->__isset.ue = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 3:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->te.read(iprot);
+          this->__isset.te = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      default:
+        xfer += iprot->skip(ftype);
+        break;
+    }
+    xfer += iprot->readFieldEnd();
+  }
+
+  xfer += iprot->readStructEnd();
+
+  return xfer;
+}
+
+uint32_t Cassandra_add_result::write(::apache::thrift::protocol::TProtocol* oprot) const {
+
+  uint32_t xfer = 0;
+
+  xfer += oprot->writeStructBegin("Cassandra_add_result");
+
+  if (this->__isset.ire) {
+    xfer += oprot->writeFieldBegin("ire", ::apache::thrift::protocol::T_STRUCT, 1);
+    xfer += this->ire.write(oprot);
+    xfer += oprot->writeFieldEnd();
+  } else if (this->__isset.ue) {
+    xfer += oprot->writeFieldBegin("ue", ::apache::thrift::protocol::T_STRUCT, 2);
+    xfer += this->ue.write(oprot);
+    xfer += oprot->writeFieldEnd();
+  } else if (this->__isset.te) {
+    xfer += oprot->writeFieldBegin("te", ::apache::thrift::protocol::T_STRUCT, 3);
+    xfer += this->te.write(oprot);
+    xfer += oprot->writeFieldEnd();
+  }
+  xfer += oprot->writeFieldStop();
+  xfer += oprot->writeStructEnd();
+  return xfer;
+}
+
+uint32_t Cassandra_add_presult::read(::apache::thrift::protocol::TProtocol* iprot) {
+
+  uint32_t xfer = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TType ftype;
+  int16_t fid;
+
+  xfer += iprot->readStructBegin(fname);
+
+  using ::apache::thrift::protocol::TProtocolException;
+
+
+  while (true)
+  {
+    xfer += iprot->readFieldBegin(fname, ftype, fid);
+    if (ftype == ::apache::thrift::protocol::T_STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->ire.read(iprot);
+          this->__isset.ire = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->ue.read(iprot);
+          this->__isset.ue = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 3:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->te.read(iprot);
+          this->__isset.te = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      default:
+        xfer += iprot->skip(ftype);
+        break;
+    }
+    xfer += iprot->readFieldEnd();
+  }
+
+  xfer += iprot->readStructEnd();
+
+  return xfer;
+}
+
 uint32_t Cassandra_remove_args::read(::apache::thrift::protocol::TProtocol* iprot) {
 
   uint32_t xfer = 0;
@@ -2835,9 +3089,9 @@ uint32_t Cassandra_remove_args::read(::apache::thrift::protocol::TProtocol* ipro
         break;
       case 4:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast156;
-          xfer += iprot->readI32(ecast156);
-          this->consistency_level = (ConsistencyLevel::type)ecast156;
+          int32_t ecast176;
+          xfer += iprot->readI32(ecast176);
+          this->consistency_level = (ConsistencyLevel::type)ecast176;
           this->__isset.consistency_level = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -3037,6 +3291,243 @@ uint32_t Cassandra_remove_presult::read(::apache::thrift::protocol::TProtocol* i
   return xfer;
 }
 
+uint32_t Cassandra_remove_counter_args::read(::apache::thrift::protocol::TProtocol* iprot) {
+
+  uint32_t xfer = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TType ftype;
+  int16_t fid;
+
+  xfer += iprot->readStructBegin(fname);
+
+  using ::apache::thrift::protocol::TProtocolException;
+
+  bool isset_key = false;
+  bool isset_path = false;
+  bool isset_consistency_level = false;
+
+  while (true)
+  {
+    xfer += iprot->readFieldBegin(fname, ftype, fid);
+    if (ftype == ::apache::thrift::protocol::T_STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+        if (ftype == ::apache::thrift::protocol::T_STRING) {
+          xfer += iprot->readBinary(this->key);
+          isset_key = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->path.read(iprot);
+          isset_path = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 3:
+        if (ftype == ::apache::thrift::protocol::T_I32) {
+          int32_t ecast177;
+          xfer += iprot->readI32(ecast177);
+          this->consistency_level = (ConsistencyLevel::type)ecast177;
+          isset_consistency_level = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      default:
+        xfer += iprot->skip(ftype);
+        break;
+    }
+    xfer += iprot->readFieldEnd();
+  }
+
+  xfer += iprot->readStructEnd();
+
+  if (!isset_key)
+    throw TProtocolException(TProtocolException::INVALID_DATA);
+  if (!isset_path)
+    throw TProtocolException(TProtocolException::INVALID_DATA);
+  if (!isset_consistency_level)
+    throw TProtocolException(TProtocolException::INVALID_DATA);
+  return xfer;
+}
+
+uint32_t Cassandra_remove_counter_args::write(::apache::thrift::protocol::TProtocol* oprot) const {
+  uint32_t xfer = 0;
+  xfer += oprot->writeStructBegin("Cassandra_remove_counter_args");
+  xfer += oprot->writeFieldBegin("key", ::apache::thrift::protocol::T_STRING, 1);
+  xfer += oprot->writeBinary(this->key);
+  xfer += oprot->writeFieldEnd();
+  xfer += oprot->writeFieldBegin("path", ::apache::thrift::protocol::T_STRUCT, 2);
+  xfer += this->path.write(oprot);
+  xfer += oprot->writeFieldEnd();
+  xfer += oprot->writeFieldBegin("consistency_level", ::apache::thrift::protocol::T_I32, 3);
+  xfer += oprot->writeI32((int32_t)this->consistency_level);
+  xfer += oprot->writeFieldEnd();
+  xfer += oprot->writeFieldStop();
+  xfer += oprot->writeStructEnd();
+  return xfer;
+}
+
+uint32_t Cassandra_remove_counter_pargs::write(::apache::thrift::protocol::TProtocol* oprot) const {
+  uint32_t xfer = 0;
+  xfer += oprot->writeStructBegin("Cassandra_remove_counter_pargs");
+  xfer += oprot->writeFieldBegin("key", ::apache::thrift::protocol::T_STRING, 1);
+  xfer += oprot->writeBinary((*(this->key)));
+  xfer += oprot->writeFieldEnd();
+  xfer += oprot->writeFieldBegin("path", ::apache::thrift::protocol::T_STRUCT, 2);
+  xfer += (*(this->path)).write(oprot);
+  xfer += oprot->writeFieldEnd();
+  xfer += oprot->writeFieldBegin("consistency_level", ::apache::thrift::protocol::T_I32, 3);
+  xfer += oprot->writeI32((int32_t)(*(this->consistency_level)));
+  xfer += oprot->writeFieldEnd();
+  xfer += oprot->writeFieldStop();
+  xfer += oprot->writeStructEnd();
+  return xfer;
+}
+
+uint32_t Cassandra_remove_counter_result::read(::apache::thrift::protocol::TProtocol* iprot) {
+
+  uint32_t xfer = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TType ftype;
+  int16_t fid;
+
+  xfer += iprot->readStructBegin(fname);
+
+  using ::apache::thrift::protocol::TProtocolException;
+
+
+  while (true)
+  {
+    xfer += iprot->readFieldBegin(fname, ftype, fid);
+    if (ftype == ::apache::thrift::protocol::T_STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->ire.read(iprot);
+          this->__isset.ire = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->ue.read(iprot);
+          this->__isset.ue = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 3:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->te.read(iprot);
+          this->__isset.te = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      default:
+        xfer += iprot->skip(ftype);
+        break;
+    }
+    xfer += iprot->readFieldEnd();
+  }
+
+  xfer += iprot->readStructEnd();
+
+  return xfer;
+}
+
+uint32_t Cassandra_remove_counter_result::write(::apache::thrift::protocol::TProtocol* oprot) const {
+
+  uint32_t xfer = 0;
+
+  xfer += oprot->writeStructBegin("Cassandra_remove_counter_result");
+
+  if (this->__isset.ire) {
+    xfer += oprot->writeFieldBegin("ire", ::apache::thrift::protocol::T_STRUCT, 1);
+    xfer += this->ire.write(oprot);
+    xfer += oprot->writeFieldEnd();
+  } else if (this->__isset.ue) {
+    xfer += oprot->writeFieldBegin("ue", ::apache::thrift::protocol::T_STRUCT, 2);
+    xfer += this->ue.write(oprot);
+    xfer += oprot->writeFieldEnd();
+  } else if (this->__isset.te) {
+    xfer += oprot->writeFieldBegin("te", ::apache::thrift::protocol::T_STRUCT, 3);
+    xfer += this->te.write(oprot);
+    xfer += oprot->writeFieldEnd();
+  }
+  xfer += oprot->writeFieldStop();
+  xfer += oprot->writeStructEnd();
+  return xfer;
+}
+
+uint32_t Cassandra_remove_counter_presult::read(::apache::thrift::protocol::TProtocol* iprot) {
+
+  uint32_t xfer = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TType ftype;
+  int16_t fid;
+
+  xfer += iprot->readStructBegin(fname);
+
+  using ::apache::thrift::protocol::TProtocolException;
+
+
+  while (true)
+  {
+    xfer += iprot->readFieldBegin(fname, ftype, fid);
+    if (ftype == ::apache::thrift::protocol::T_STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->ire.read(iprot);
+          this->__isset.ire = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->ue.read(iprot);
+          this->__isset.ue = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 3:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->te.read(iprot);
+          this->__isset.te = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      default:
+        xfer += iprot->skip(ftype);
+        break;
+    }
+    xfer += iprot->readFieldEnd();
+  }
+
+  xfer += iprot->readStructEnd();
+
+  return xfer;
+}
+
 uint32_t Cassandra_batch_mutate_args::read(::apache::thrift::protocol::TProtocol* iprot) {
 
   uint32_t xfer = 0;
@@ -3063,38 +3554,38 @@ uint32_t Cassandra_batch_mutate_args::read(::apache::thrift::protocol::TProtocol
         if (ftype == ::apache::thrift::protocol::T_MAP) {
           {
             this->mutation_map.clear();
-            uint32_t _size157;
-            ::apache::thrift::protocol::TType _ktype158;
-            ::apache::thrift::protocol::TType _vtype159;
-            iprot->readMapBegin(_ktype158, _vtype159, _size157);
-            uint32_t _i161;
-            for (_i161 = 0; _i161 < _size157; ++_i161)
+            uint32_t _size178;
+            ::apache::thrift::protocol::TType _ktype179;
+            ::apache::thrift::protocol::TType _vtype180;
+            iprot->readMapBegin(_ktype179, _vtype180, _size178);
+            uint32_t _i182;
+            for (_i182 = 0; _i182 < _size178; ++_i182)
             {
-              std::string _key162;
-              xfer += iprot->readBinary(_key162);
-              std::map<std::string, std::vector<Mutation> > & _val163 = this->mutation_map[_key162];
+              std::string _key183;
+              xfer += iprot->readBinary(_key183);
+              std::map<std::string, std::vector<Mutation> > & _val184 = this->mutation_map[_key183];
               {
-                _val163.clear();
-                uint32_t _size164;
-                ::apache::thrift::protocol::TType _ktype165;
-                ::apache::thrift::protocol::TType _vtype166;
-                iprot->readMapBegin(_ktype165, _vtype166, _size164);
-                uint32_t _i168;
-                for (_i168 = 0; _i168 < _size164; ++_i168)
+                _val184.clear();
+                uint32_t _size185;
+                ::apache::thrift::protocol::TType _ktype186;
+                ::apache::thrift::protocol::TType _vtype187;
+                iprot->readMapBegin(_ktype186, _vtype187, _size185);
+                uint32_t _i189;
+                for (_i189 = 0; _i189 < _size185; ++_i189)
                 {
-                  std::string _key169;
-                  xfer += iprot->readString(_key169);
-                  std::vector<Mutation> & _val170 = _val163[_key169];
+                  std::string _key190;
+                  xfer += iprot->readString(_key190);
+                  std::vector<Mutation> & _val191 = _val184[_key190];
                   {
-                    _val170.clear();
-                    uint32_t _size171;
-                    ::apache::thrift::protocol::TType _etype174;
-                    iprot->readListBegin(_etype174, _size171);
-                    _val170.resize(_size171);
-                    uint32_t _i175;
-                    for (_i175 = 0; _i175 < _size171; ++_i175)
+                    _val191.clear();
+                    uint32_t _size192;
+                    ::apache::thrift::protocol::TType _etype195;
+                    iprot->readListBegin(_etype195, _size192);
+                    _val191.resize(_size192);
+                    uint32_t _i196;
+                    for (_i196 = 0; _i196 < _size192; ++_i196)
                     {
-                      xfer += _val170[_i175].read(iprot);
+                      xfer += _val191[_i196].read(iprot);
                     }
                     iprot->readListEnd();
                   }
@@ -3111,9 +3602,9 @@ uint32_t Cassandra_batch_mutate_args::read(::apache::thrift::protocol::TProtocol
         break;
       case 2:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast176;
-          xfer += iprot->readI32(ecast176);
-          this->consistency_level = (ConsistencyLevel::type)ecast176;
+          int32_t ecast197;
+          xfer += iprot->readI32(ecast197);
+          this->consistency_level = (ConsistencyLevel::type)ecast197;
           isset_consistency_level = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -3141,22 +3632,22 @@ uint32_t Cassandra_batch_mutate_args::write(::apache::thrift::protocol::TProtoco
   xfer += oprot->writeFieldBegin("mutation_map", ::apache::thrift::protocol::T_MAP, 1);
   {
     xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_STRING, ::apache::thrift::protocol::T_MAP, this->mutation_map.size());
-    std::map<std::string, std::map<std::string, std::vector<Mutation> > > ::const_iterator _iter177;
-    for (_iter177 = this->mutation_map.begin(); _iter177 != this->mutation_map.end(); ++_iter177)
+    std::map<std::string, std::map<std::string, std::vector<Mutation> > > ::const_iterator _iter198;
+    for (_iter198 = this->mutation_map.begin(); _iter198 != this->mutation_map.end(); ++_iter198)
     {
-      xfer += oprot->writeBinary(_iter177->first);
+      xfer += oprot->writeBinary(_iter198->first);
       {
-        xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_STRING, ::apache::thrift::protocol::T_LIST, _iter177->second.size());
-        std::map<std::string, std::vector<Mutation> > ::const_iterator _iter178;
-        for (_iter178 = _iter177->second.begin(); _iter178 != _iter177->second.end(); ++_iter178)
+        xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_STRING, ::apache::thrift::protocol::T_LIST, _iter198->second.size());
+        std::map<std::string, std::vector<Mutation> > ::const_iterator _iter199;
+        for (_iter199 = _iter198->second.begin(); _iter199 != _iter198->second.end(); ++_iter199)
         {
-          xfer += oprot->writeString(_iter178->first);
+          xfer += oprot->writeString(_iter199->first);
           {
-            xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, _iter178->second.size());
-            std::vector<Mutation> ::const_iterator _iter179;
-            for (_iter179 = _iter178->second.begin(); _iter179 != _iter178->second.end(); ++_iter179)
+            xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, _iter199->second.size());
+            std::vector<Mutation> ::const_iterator _iter200;
+            for (_iter200 = _iter199->second.begin(); _iter200 != _iter199->second.end(); ++_iter200)
             {
-              xfer += (*_iter179).write(oprot);
+              xfer += (*_iter200).write(oprot);
             }
             xfer += oprot->writeListEnd();
           }
@@ -3181,22 +3672,22 @@ uint32_t Cassandra_batch_mutate_pargs::write(::apache::thrift::protocol::TProtoc
   xfer += oprot->writeFieldBegin("mutation_map", ::apache::thrift::protocol::T_MAP, 1);
   {
     xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_STRING, ::apache::thrift::protocol::T_MAP, (*(this->mutation_map)).size());
-    std::map<std::string, std::map<std::string, std::vector<Mutation> > > ::const_iterator _iter180;
-    for (_iter180 = (*(this->mutation_map)).begin(); _iter180 != (*(this->mutation_map)).end(); ++_iter180)
+    std::map<std::string, std::map<std::string, std::vector<Mutation> > > ::const_iterator _iter201;
+    for (_iter201 = (*(this->mutation_map)).begin(); _iter201 != (*(this->mutation_map)).end(); ++_iter201)
     {
-      xfer += oprot->writeBinary(_iter180->first);
+      xfer += oprot->writeBinary(_iter201->first);
       {
-        xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_STRING, ::apache::thrift::protocol::T_LIST, _iter180->second.size());
-        std::map<std::string, std::vector<Mutation> > ::const_iterator _iter181;
-        for (_iter181 = _iter180->second.begin(); _iter181 != _iter180->second.end(); ++_iter181)
+        xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_STRING, ::apache::thrift::protocol::T_LIST, _iter201->second.size());
+        std::map<std::string, std::vector<Mutation> > ::const_iterator _iter202;
+        for (_iter202 = _iter201->second.begin(); _iter202 != _iter201->second.end(); ++_iter202)
         {
-          xfer += oprot->writeString(_iter181->first);
+          xfer += oprot->writeString(_iter202->first);
           {
-            xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, _iter181->second.size());
-            std::vector<Mutation> ::const_iterator _iter182;
-            for (_iter182 = _iter181->second.begin(); _iter182 != _iter181->second.end(); ++_iter182)
+            xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, _iter202->second.size());
+            std::vector<Mutation> ::const_iterator _iter203;
+            for (_iter203 = _iter202->second.begin(); _iter203 != _iter202->second.end(); ++_iter203)
             {
-              xfer += (*_iter182).write(oprot);
+              xfer += (*_iter203).write(oprot);
             }
             xfer += oprot->writeListEnd();
           }
@@ -3604,26 +4095,26 @@ uint32_t Cassandra_describe_schema_versions_result::read(::apache::thrift::proto
         if (ftype == ::apache::thrift::protocol::T_MAP) {
           {
             this->success.clear();
-            uint32_t _size183;
-            ::apache::thrift::protocol::TType _ktype184;
-            ::apache::thrift::protocol::TType _vtype185;
-            iprot->readMapBegin(_ktype184, _vtype185, _size183);
-            uint32_t _i187;
-            for (_i187 = 0; _i187 < _size183; ++_i187)
+            uint32_t _size204;
+            ::apache::thrift::protocol::TType _ktype205;
+            ::apache::thrift::protocol::TType _vtype206;
+            iprot->readMapBegin(_ktype205, _vtype206, _size204);
+            uint32_t _i208;
+            for (_i208 = 0; _i208 < _size204; ++_i208)
             {
-              std::string _key188;
-              xfer += iprot->readString(_key188);
-              std::vector<std::string> & _val189 = this->success[_key188];
+              std::string _key209;
+              xfer += iprot->readString(_key209);
+              std::vector<std::string> & _val210 = this->success[_key209];
               {
-                _val189.clear();
-                uint32_t _size190;
-                ::apache::thrift::protocol::TType _etype193;
-                iprot->readListBegin(_etype193, _size190);
-                _val189.resize(_size190);
-                uint32_t _i194;
-                for (_i194 = 0; _i194 < _size190; ++_i194)
+                _val210.clear();
+                uint32_t _size211;
+                ::apache::thrift::protocol::TType _etype214;
+                iprot->readListBegin(_etype214, _size211);
+                _val210.resize(_size211);
+                uint32_t _i215;
+                for (_i215 = 0; _i215 < _size211; ++_i215)
                 {
-                  xfer += iprot->readString(_val189[_i194]);
+                  xfer += iprot->readString(_val210[_i215]);
                 }
                 iprot->readListEnd();
               }
@@ -3665,16 +4156,16 @@ uint32_t Cassandra_describe_schema_versions_result::write(::apache::thrift::prot
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_MAP, 0);
     {
       xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_STRING, ::apache::thrift::protocol::T_LIST, this->success.size());
-      std::map<std::string, std::vector<std::string> > ::const_iterator _iter195;
-      for (_iter195 = this->success.begin(); _iter195 != this->success.end(); ++_iter195)
+      std::map<std::string, std::vector<std::string> > ::const_iterator _iter216;
+      for (_iter216 = this->success.begin(); _iter216 != this->success.end(); ++_iter216)
       {
-        xfer += oprot->writeString(_iter195->first);
+        xfer += oprot->writeString(_iter216->first);
         {
-          xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, _iter195->second.size());
-          std::vector<std::string> ::const_iterator _iter196;
-          for (_iter196 = _iter195->second.begin(); _iter196 != _iter195->second.end(); ++_iter196)
+          xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, _iter216->second.size());
+          std::vector<std::string> ::const_iterator _iter217;
+          for (_iter217 = _iter216->second.begin(); _iter217 != _iter216->second.end(); ++_iter217)
           {
-            xfer += oprot->writeString((*_iter196));
+            xfer += oprot->writeString((*_iter217));
           }
           xfer += oprot->writeListEnd();
         }
@@ -3716,26 +4207,26 @@ uint32_t Cassandra_describe_schema_versions_presult::read(::apache::thrift::prot
         if (ftype == ::apache::thrift::protocol::T_MAP) {
           {
             (*(this->success)).clear();
-            uint32_t _size197;
-            ::apache::thrift::protocol::TType _ktype198;
-            ::apache::thrift::protocol::TType _vtype199;
-            iprot->readMapBegin(_ktype198, _vtype199, _size197);
-            uint32_t _i201;
-            for (_i201 = 0; _i201 < _size197; ++_i201)
+            uint32_t _size218;
+            ::apache::thrift::protocol::TType _ktype219;
+            ::apache::thrift::protocol::TType _vtype220;
+            iprot->readMapBegin(_ktype219, _vtype220, _size218);
+            uint32_t _i222;
+            for (_i222 = 0; _i222 < _size218; ++_i222)
             {
-              std::string _key202;
-              xfer += iprot->readString(_key202);
-              std::vector<std::string> & _val203 = (*(this->success))[_key202];
+              std::string _key223;
+              xfer += iprot->readString(_key223);
+              std::vector<std::string> & _val224 = (*(this->success))[_key223];
               {
-                _val203.clear();
-                uint32_t _size204;
-                ::apache::thrift::protocol::TType _etype207;
-                iprot->readListBegin(_etype207, _size204);
-                _val203.resize(_size204);
-                uint32_t _i208;
-                for (_i208 = 0; _i208 < _size204; ++_i208)
+                _val224.clear();
+                uint32_t _size225;
+                ::apache::thrift::protocol::TType _etype228;
+                iprot->readListBegin(_etype228, _size225);
+                _val224.resize(_size225);
+                uint32_t _i229;
+                for (_i229 = 0; _i229 < _size225; ++_i229)
                 {
-                  xfer += iprot->readString(_val203[_i208]);
+                  xfer += iprot->readString(_val224[_i229]);
                 }
                 iprot->readListEnd();
               }
@@ -3839,14 +4330,14 @@ uint32_t Cassandra_describe_keyspaces_result::read(::apache::thrift::protocol::T
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size209;
-            ::apache::thrift::protocol::TType _etype212;
-            iprot->readListBegin(_etype212, _size209);
-            this->success.resize(_size209);
-            uint32_t _i213;
-            for (_i213 = 0; _i213 < _size209; ++_i213)
+            uint32_t _size230;
+            ::apache::thrift::protocol::TType _etype233;
+            iprot->readListBegin(_etype233, _size230);
+            this->success.resize(_size230);
+            uint32_t _i234;
+            for (_i234 = 0; _i234 < _size230; ++_i234)
             {
-              xfer += this->success[_i213].read(iprot);
+              xfer += this->success[_i234].read(iprot);
             }
             iprot->readListEnd();
           }
@@ -3885,10 +4376,10 @@ uint32_t Cassandra_describe_keyspaces_result::write(::apache::thrift::protocol::
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, this->success.size());
-      std::vector<KsDef> ::const_iterator _iter214;
-      for (_iter214 = this->success.begin(); _iter214 != this->success.end(); ++_iter214)
+      std::vector<KsDef> ::const_iterator _iter235;
+      for (_iter235 = this->success.begin(); _iter235 != this->success.end(); ++_iter235)
       {
-        xfer += (*_iter214).write(oprot);
+        xfer += (*_iter235).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -3927,14 +4418,14 @@ uint32_t Cassandra_describe_keyspaces_presult::read(::apache::thrift::protocol::
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size215;
-            ::apache::thrift::protocol::TType _etype218;
-            iprot->readListBegin(_etype218, _size215);
-            (*(this->success)).resize(_size215);
-            uint32_t _i219;
-            for (_i219 = 0; _i219 < _size215; ++_i219)
+            uint32_t _size236;
+            ::apache::thrift::protocol::TType _etype239;
+            iprot->readListBegin(_etype239, _size236);
+            (*(this->success)).resize(_size236);
+            uint32_t _i240;
+            for (_i240 = 0; _i240 < _size236; ++_i240)
             {
-              xfer += (*(this->success))[_i219].read(iprot);
+              xfer += (*(this->success))[_i240].read(iprot);
             }
             iprot->readListEnd();
           }
@@ -4340,14 +4831,14 @@ uint32_t Cassandra_describe_ring_result::read(::apache::thrift::protocol::TProto
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size220;
-            ::apache::thrift::protocol::TType _etype223;
-            iprot->readListBegin(_etype223, _size220);
-            this->success.resize(_size220);
-            uint32_t _i224;
-            for (_i224 = 0; _i224 < _size220; ++_i224)
+            uint32_t _size241;
+            ::apache::thrift::protocol::TType _etype244;
+            iprot->readListBegin(_etype244, _size241);
+            this->success.resize(_size241);
+            uint32_t _i245;
+            for (_i245 = 0; _i245 < _size241; ++_i245)
             {
-              xfer += this->success[_i224].read(iprot);
+              xfer += this->success[_i245].read(iprot);
             }
             iprot->readListEnd();
           }
@@ -4386,10 +4877,10 @@ uint32_t Cassandra_describe_ring_result::write(::apache::thrift::protocol::TProt
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, this->success.size());
-      std::vector<TokenRange> ::const_iterator _iter225;
-      for (_iter225 = this->success.begin(); _iter225 != this->success.end(); ++_iter225)
+      std::vector<TokenRange> ::const_iterator _iter246;
+      for (_iter246 = this->success.begin(); _iter246 != this->success.end(); ++_iter246)
       {
-        xfer += (*_iter225).write(oprot);
+        xfer += (*_iter246).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -4428,14 +4919,14 @@ uint32_t Cassandra_describe_ring_presult::read(::apache::thrift::protocol::TProt
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size226;
-            ::apache::thrift::protocol::TType _etype229;
-            iprot->readListBegin(_etype229, _size226);
-            (*(this->success)).resize(_size226);
-            uint32_t _i230;
-            for (_i230 = 0; _i230 < _size226; ++_i230)
+            uint32_t _size247;
+            ::apache::thrift::protocol::TType _etype250;
+            iprot->readListBegin(_etype250, _size247);
+            (*(this->success)).resize(_size247);
+            uint32_t _i251;
+            for (_i251 = 0; _i251 < _size247; ++_i251)
             {
-              xfer += (*(this->success))[_i230].read(iprot);
+              xfer += (*(this->success))[_i251].read(iprot);
             }
             iprot->readListEnd();
           }
@@ -5093,18 +5584,26 @@ uint32_t Cassandra_describe_splits_result::read(::apache::thrift::protocol::TPro
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size231;
-            ::apache::thrift::protocol::TType _etype234;
-            iprot->readListBegin(_etype234, _size231);
-            this->success.resize(_size231);
-            uint32_t _i235;
-            for (_i235 = 0; _i235 < _size231; ++_i235)
+            uint32_t _size252;
+            ::apache::thrift::protocol::TType _etype255;
+            iprot->readListBegin(_etype255, _size252);
+            this->success.resize(_size252);
+            uint32_t _i256;
+            for (_i256 = 0; _i256 < _size252; ++_i256)
             {
-              xfer += iprot->readString(this->success[_i235]);
+              xfer += iprot->readString(this->success[_i256]);
             }
             iprot->readListEnd();
           }
           this->__isset.success = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 1:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->ire.read(iprot);
+          this->__isset.ire = true;
         } else {
           xfer += iprot->skip(ftype);
         }
@@ -5131,13 +5630,17 @@ uint32_t Cassandra_describe_splits_result::write(::apache::thrift::protocol::TPr
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, this->success.size());
-      std::vector<std::string> ::const_iterator _iter236;
-      for (_iter236 = this->success.begin(); _iter236 != this->success.end(); ++_iter236)
+      std::vector<std::string> ::const_iterator _iter257;
+      for (_iter257 = this->success.begin(); _iter257 != this->success.end(); ++_iter257)
       {
-        xfer += oprot->writeString((*_iter236));
+        xfer += oprot->writeString((*_iter257));
       }
       xfer += oprot->writeListEnd();
     }
+    xfer += oprot->writeFieldEnd();
+  } else if (this->__isset.ire) {
+    xfer += oprot->writeFieldBegin("ire", ::apache::thrift::protocol::T_STRUCT, 1);
+    xfer += this->ire.write(oprot);
     xfer += oprot->writeFieldEnd();
   }
   xfer += oprot->writeFieldStop();
@@ -5169,18 +5672,26 @@ uint32_t Cassandra_describe_splits_presult::read(::apache::thrift::protocol::TPr
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size237;
-            ::apache::thrift::protocol::TType _etype240;
-            iprot->readListBegin(_etype240, _size237);
-            (*(this->success)).resize(_size237);
-            uint32_t _i241;
-            for (_i241 = 0; _i241 < _size237; ++_i241)
+            uint32_t _size258;
+            ::apache::thrift::protocol::TType _etype261;
+            iprot->readListBegin(_etype261, _size258);
+            (*(this->success)).resize(_size258);
+            uint32_t _i262;
+            for (_i262 = 0; _i262 < _size258; ++_i262)
             {
-              xfer += iprot->readString((*(this->success))[_i241]);
+              xfer += iprot->readString((*(this->success))[_i262]);
             }
             iprot->readListEnd();
           }
           this->__isset.success = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 1:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->ire.read(iprot);
+          this->__isset.ire = true;
         } else {
           xfer += iprot->skip(ftype);
         }
@@ -5298,6 +5809,14 @@ uint32_t Cassandra_system_add_column_family_result::read(::apache::thrift::proto
           xfer += iprot->skip(ftype);
         }
         break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->sde.read(iprot);
+          this->__isset.sde = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
       default:
         xfer += iprot->skip(ftype);
         break;
@@ -5323,6 +5842,10 @@ uint32_t Cassandra_system_add_column_family_result::write(::apache::thrift::prot
   } else if (this->__isset.ire) {
     xfer += oprot->writeFieldBegin("ire", ::apache::thrift::protocol::T_STRUCT, 1);
     xfer += this->ire.write(oprot);
+    xfer += oprot->writeFieldEnd();
+  } else if (this->__isset.sde) {
+    xfer += oprot->writeFieldBegin("sde", ::apache::thrift::protocol::T_STRUCT, 2);
+    xfer += this->sde.write(oprot);
     xfer += oprot->writeFieldEnd();
   }
   xfer += oprot->writeFieldStop();
@@ -5362,6 +5885,14 @@ uint32_t Cassandra_system_add_column_family_presult::read(::apache::thrift::prot
         if (ftype == ::apache::thrift::protocol::T_STRUCT) {
           xfer += this->ire.read(iprot);
           this->__isset.ire = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->sde.read(iprot);
+          this->__isset.sde = true;
         } else {
           xfer += iprot->skip(ftype);
         }
@@ -5479,6 +6010,14 @@ uint32_t Cassandra_system_drop_column_family_result::read(::apache::thrift::prot
           xfer += iprot->skip(ftype);
         }
         break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->sde.read(iprot);
+          this->__isset.sde = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
       default:
         xfer += iprot->skip(ftype);
         break;
@@ -5504,6 +6043,10 @@ uint32_t Cassandra_system_drop_column_family_result::write(::apache::thrift::pro
   } else if (this->__isset.ire) {
     xfer += oprot->writeFieldBegin("ire", ::apache::thrift::protocol::T_STRUCT, 1);
     xfer += this->ire.write(oprot);
+    xfer += oprot->writeFieldEnd();
+  } else if (this->__isset.sde) {
+    xfer += oprot->writeFieldBegin("sde", ::apache::thrift::protocol::T_STRUCT, 2);
+    xfer += this->sde.write(oprot);
     xfer += oprot->writeFieldEnd();
   }
   xfer += oprot->writeFieldStop();
@@ -5543,6 +6086,14 @@ uint32_t Cassandra_system_drop_column_family_presult::read(::apache::thrift::pro
         if (ftype == ::apache::thrift::protocol::T_STRUCT) {
           xfer += this->ire.read(iprot);
           this->__isset.ire = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->sde.read(iprot);
+          this->__isset.sde = true;
         } else {
           xfer += iprot->skip(ftype);
         }
@@ -5660,6 +6211,14 @@ uint32_t Cassandra_system_add_keyspace_result::read(::apache::thrift::protocol::
           xfer += iprot->skip(ftype);
         }
         break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->sde.read(iprot);
+          this->__isset.sde = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
       default:
         xfer += iprot->skip(ftype);
         break;
@@ -5685,6 +6244,10 @@ uint32_t Cassandra_system_add_keyspace_result::write(::apache::thrift::protocol:
   } else if (this->__isset.ire) {
     xfer += oprot->writeFieldBegin("ire", ::apache::thrift::protocol::T_STRUCT, 1);
     xfer += this->ire.write(oprot);
+    xfer += oprot->writeFieldEnd();
+  } else if (this->__isset.sde) {
+    xfer += oprot->writeFieldBegin("sde", ::apache::thrift::protocol::T_STRUCT, 2);
+    xfer += this->sde.write(oprot);
     xfer += oprot->writeFieldEnd();
   }
   xfer += oprot->writeFieldStop();
@@ -5724,6 +6287,14 @@ uint32_t Cassandra_system_add_keyspace_presult::read(::apache::thrift::protocol:
         if (ftype == ::apache::thrift::protocol::T_STRUCT) {
           xfer += this->ire.read(iprot);
           this->__isset.ire = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->sde.read(iprot);
+          this->__isset.sde = true;
         } else {
           xfer += iprot->skip(ftype);
         }
@@ -5841,6 +6412,14 @@ uint32_t Cassandra_system_drop_keyspace_result::read(::apache::thrift::protocol:
           xfer += iprot->skip(ftype);
         }
         break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->sde.read(iprot);
+          this->__isset.sde = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
       default:
         xfer += iprot->skip(ftype);
         break;
@@ -5866,6 +6445,10 @@ uint32_t Cassandra_system_drop_keyspace_result::write(::apache::thrift::protocol
   } else if (this->__isset.ire) {
     xfer += oprot->writeFieldBegin("ire", ::apache::thrift::protocol::T_STRUCT, 1);
     xfer += this->ire.write(oprot);
+    xfer += oprot->writeFieldEnd();
+  } else if (this->__isset.sde) {
+    xfer += oprot->writeFieldBegin("sde", ::apache::thrift::protocol::T_STRUCT, 2);
+    xfer += this->sde.write(oprot);
     xfer += oprot->writeFieldEnd();
   }
   xfer += oprot->writeFieldStop();
@@ -5905,6 +6488,14 @@ uint32_t Cassandra_system_drop_keyspace_presult::read(::apache::thrift::protocol
         if (ftype == ::apache::thrift::protocol::T_STRUCT) {
           xfer += this->ire.read(iprot);
           this->__isset.ire = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->sde.read(iprot);
+          this->__isset.sde = true;
         } else {
           xfer += iprot->skip(ftype);
         }
@@ -6022,6 +6613,14 @@ uint32_t Cassandra_system_update_keyspace_result::read(::apache::thrift::protoco
           xfer += iprot->skip(ftype);
         }
         break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->sde.read(iprot);
+          this->__isset.sde = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
       default:
         xfer += iprot->skip(ftype);
         break;
@@ -6047,6 +6646,10 @@ uint32_t Cassandra_system_update_keyspace_result::write(::apache::thrift::protoc
   } else if (this->__isset.ire) {
     xfer += oprot->writeFieldBegin("ire", ::apache::thrift::protocol::T_STRUCT, 1);
     xfer += this->ire.write(oprot);
+    xfer += oprot->writeFieldEnd();
+  } else if (this->__isset.sde) {
+    xfer += oprot->writeFieldBegin("sde", ::apache::thrift::protocol::T_STRUCT, 2);
+    xfer += this->sde.write(oprot);
     xfer += oprot->writeFieldEnd();
   }
   xfer += oprot->writeFieldStop();
@@ -6086,6 +6689,14 @@ uint32_t Cassandra_system_update_keyspace_presult::read(::apache::thrift::protoc
         if (ftype == ::apache::thrift::protocol::T_STRUCT) {
           xfer += this->ire.read(iprot);
           this->__isset.ire = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->sde.read(iprot);
+          this->__isset.sde = true;
         } else {
           xfer += iprot->skip(ftype);
         }
@@ -6203,6 +6814,14 @@ uint32_t Cassandra_system_update_column_family_result::read(::apache::thrift::pr
           xfer += iprot->skip(ftype);
         }
         break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->sde.read(iprot);
+          this->__isset.sde = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
       default:
         xfer += iprot->skip(ftype);
         break;
@@ -6228,6 +6847,10 @@ uint32_t Cassandra_system_update_column_family_result::write(::apache::thrift::p
   } else if (this->__isset.ire) {
     xfer += oprot->writeFieldBegin("ire", ::apache::thrift::protocol::T_STRUCT, 1);
     xfer += this->ire.write(oprot);
+    xfer += oprot->writeFieldEnd();
+  } else if (this->__isset.sde) {
+    xfer += oprot->writeFieldBegin("sde", ::apache::thrift::protocol::T_STRUCT, 2);
+    xfer += this->sde.write(oprot);
     xfer += oprot->writeFieldEnd();
   }
   xfer += oprot->writeFieldStop();
@@ -6267,6 +6890,274 @@ uint32_t Cassandra_system_update_column_family_presult::read(::apache::thrift::p
         if (ftype == ::apache::thrift::protocol::T_STRUCT) {
           xfer += this->ire.read(iprot);
           this->__isset.ire = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->sde.read(iprot);
+          this->__isset.sde = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      default:
+        xfer += iprot->skip(ftype);
+        break;
+    }
+    xfer += iprot->readFieldEnd();
+  }
+
+  xfer += iprot->readStructEnd();
+
+  return xfer;
+}
+
+uint32_t Cassandra_execute_cql_query_args::read(::apache::thrift::protocol::TProtocol* iprot) {
+
+  uint32_t xfer = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TType ftype;
+  int16_t fid;
+
+  xfer += iprot->readStructBegin(fname);
+
+  using ::apache::thrift::protocol::TProtocolException;
+
+  bool isset_query = false;
+  bool isset_compression = false;
+
+  while (true)
+  {
+    xfer += iprot->readFieldBegin(fname, ftype, fid);
+    if (ftype == ::apache::thrift::protocol::T_STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+        if (ftype == ::apache::thrift::protocol::T_STRING) {
+          xfer += iprot->readBinary(this->query);
+          isset_query = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_I32) {
+          int32_t ecast263;
+          xfer += iprot->readI32(ecast263);
+          this->compression = (Compression::type)ecast263;
+          isset_compression = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      default:
+        xfer += iprot->skip(ftype);
+        break;
+    }
+    xfer += iprot->readFieldEnd();
+  }
+
+  xfer += iprot->readStructEnd();
+
+  if (!isset_query)
+    throw TProtocolException(TProtocolException::INVALID_DATA);
+  if (!isset_compression)
+    throw TProtocolException(TProtocolException::INVALID_DATA);
+  return xfer;
+}
+
+uint32_t Cassandra_execute_cql_query_args::write(::apache::thrift::protocol::TProtocol* oprot) const {
+  uint32_t xfer = 0;
+  xfer += oprot->writeStructBegin("Cassandra_execute_cql_query_args");
+  xfer += oprot->writeFieldBegin("query", ::apache::thrift::protocol::T_STRING, 1);
+  xfer += oprot->writeBinary(this->query);
+  xfer += oprot->writeFieldEnd();
+  xfer += oprot->writeFieldBegin("compression", ::apache::thrift::protocol::T_I32, 2);
+  xfer += oprot->writeI32((int32_t)this->compression);
+  xfer += oprot->writeFieldEnd();
+  xfer += oprot->writeFieldStop();
+  xfer += oprot->writeStructEnd();
+  return xfer;
+}
+
+uint32_t Cassandra_execute_cql_query_pargs::write(::apache::thrift::protocol::TProtocol* oprot) const {
+  uint32_t xfer = 0;
+  xfer += oprot->writeStructBegin("Cassandra_execute_cql_query_pargs");
+  xfer += oprot->writeFieldBegin("query", ::apache::thrift::protocol::T_STRING, 1);
+  xfer += oprot->writeBinary((*(this->query)));
+  xfer += oprot->writeFieldEnd();
+  xfer += oprot->writeFieldBegin("compression", ::apache::thrift::protocol::T_I32, 2);
+  xfer += oprot->writeI32((int32_t)(*(this->compression)));
+  xfer += oprot->writeFieldEnd();
+  xfer += oprot->writeFieldStop();
+  xfer += oprot->writeStructEnd();
+  return xfer;
+}
+
+uint32_t Cassandra_execute_cql_query_result::read(::apache::thrift::protocol::TProtocol* iprot) {
+
+  uint32_t xfer = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TType ftype;
+  int16_t fid;
+
+  xfer += iprot->readStructBegin(fname);
+
+  using ::apache::thrift::protocol::TProtocolException;
+
+
+  while (true)
+  {
+    xfer += iprot->readFieldBegin(fname, ftype, fid);
+    if (ftype == ::apache::thrift::protocol::T_STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 0:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->success.read(iprot);
+          this->__isset.success = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 1:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->ire.read(iprot);
+          this->__isset.ire = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->ue.read(iprot);
+          this->__isset.ue = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 3:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->te.read(iprot);
+          this->__isset.te = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 4:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->sde.read(iprot);
+          this->__isset.sde = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      default:
+        xfer += iprot->skip(ftype);
+        break;
+    }
+    xfer += iprot->readFieldEnd();
+  }
+
+  xfer += iprot->readStructEnd();
+
+  return xfer;
+}
+
+uint32_t Cassandra_execute_cql_query_result::write(::apache::thrift::protocol::TProtocol* oprot) const {
+
+  uint32_t xfer = 0;
+
+  xfer += oprot->writeStructBegin("Cassandra_execute_cql_query_result");
+
+  if (this->__isset.success) {
+    xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_STRUCT, 0);
+    xfer += this->success.write(oprot);
+    xfer += oprot->writeFieldEnd();
+  } else if (this->__isset.ire) {
+    xfer += oprot->writeFieldBegin("ire", ::apache::thrift::protocol::T_STRUCT, 1);
+    xfer += this->ire.write(oprot);
+    xfer += oprot->writeFieldEnd();
+  } else if (this->__isset.ue) {
+    xfer += oprot->writeFieldBegin("ue", ::apache::thrift::protocol::T_STRUCT, 2);
+    xfer += this->ue.write(oprot);
+    xfer += oprot->writeFieldEnd();
+  } else if (this->__isset.te) {
+    xfer += oprot->writeFieldBegin("te", ::apache::thrift::protocol::T_STRUCT, 3);
+    xfer += this->te.write(oprot);
+    xfer += oprot->writeFieldEnd();
+  } else if (this->__isset.sde) {
+    xfer += oprot->writeFieldBegin("sde", ::apache::thrift::protocol::T_STRUCT, 4);
+    xfer += this->sde.write(oprot);
+    xfer += oprot->writeFieldEnd();
+  }
+  xfer += oprot->writeFieldStop();
+  xfer += oprot->writeStructEnd();
+  return xfer;
+}
+
+uint32_t Cassandra_execute_cql_query_presult::read(::apache::thrift::protocol::TProtocol* iprot) {
+
+  uint32_t xfer = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TType ftype;
+  int16_t fid;
+
+  xfer += iprot->readStructBegin(fname);
+
+  using ::apache::thrift::protocol::TProtocolException;
+
+
+  while (true)
+  {
+    xfer += iprot->readFieldBegin(fname, ftype, fid);
+    if (ftype == ::apache::thrift::protocol::T_STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 0:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += (*(this->success)).read(iprot);
+          this->__isset.success = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 1:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->ire.read(iprot);
+          this->__isset.ire = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->ue.read(iprot);
+          this->__isset.ue = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 3:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->te.read(iprot);
+          this->__isset.te = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 4:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->sde.read(iprot);
+          this->__isset.sde = true;
         } else {
           xfer += iprot->skip(ftype);
         }
@@ -6975,6 +7866,73 @@ void CassandraClient::recv_insert()
   return;
 }
 
+void CassandraClient::add(const std::string& key, const ColumnParent& column_parent, const CounterColumn& column, const ConsistencyLevel::type consistency_level)
+{
+  send_add(key, column_parent, column, consistency_level);
+  recv_add();
+}
+
+void CassandraClient::send_add(const std::string& key, const ColumnParent& column_parent, const CounterColumn& column, const ConsistencyLevel::type consistency_level)
+{
+  int32_t cseqid = 0;
+  oprot_->writeMessageBegin("add", ::apache::thrift::protocol::T_CALL, cseqid);
+
+  Cassandra_add_pargs args;
+  args.key = &key;
+  args.column_parent = &column_parent;
+  args.column = &column;
+  args.consistency_level = &consistency_level;
+  args.write(oprot_);
+
+  oprot_->writeMessageEnd();
+  oprot_->getTransport()->flush();
+  oprot_->getTransport()->writeEnd();
+}
+
+void CassandraClient::recv_add()
+{
+
+  int32_t rseqid = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TMessageType mtype;
+
+  iprot_->readMessageBegin(fname, mtype, rseqid);
+  if (mtype == ::apache::thrift::protocol::T_EXCEPTION) {
+    ::apache::thrift::TApplicationException x;
+    x.read(iprot_);
+    iprot_->readMessageEnd();
+    iprot_->getTransport()->readEnd();
+    throw x;
+  }
+  if (mtype != ::apache::thrift::protocol::T_REPLY) {
+    iprot_->skip(::apache::thrift::protocol::T_STRUCT);
+    iprot_->readMessageEnd();
+    iprot_->getTransport()->readEnd();
+    throw ::apache::thrift::TApplicationException(::apache::thrift::TApplicationException::INVALID_MESSAGE_TYPE);
+  }
+  if (fname.compare("add") != 0) {
+    iprot_->skip(::apache::thrift::protocol::T_STRUCT);
+    iprot_->readMessageEnd();
+    iprot_->getTransport()->readEnd();
+    throw ::apache::thrift::TApplicationException(::apache::thrift::TApplicationException::WRONG_METHOD_NAME);
+  }
+  Cassandra_add_presult result;
+  result.read(iprot_);
+  iprot_->readMessageEnd();
+  iprot_->getTransport()->readEnd();
+
+  if (result.__isset.ire) {
+    throw result.ire;
+  }
+  if (result.__isset.ue) {
+    throw result.ue;
+  }
+  if (result.__isset.te) {
+    throw result.te;
+  }
+  return;
+}
+
 void CassandraClient::remove(const std::string& key, const ColumnPath& column_path, const int64_t timestamp, const ConsistencyLevel::type consistency_level)
 {
   send_remove(key, column_path, timestamp, consistency_level);
@@ -7026,6 +7984,72 @@ void CassandraClient::recv_remove()
     throw ::apache::thrift::TApplicationException(::apache::thrift::TApplicationException::WRONG_METHOD_NAME);
   }
   Cassandra_remove_presult result;
+  result.read(iprot_);
+  iprot_->readMessageEnd();
+  iprot_->getTransport()->readEnd();
+
+  if (result.__isset.ire) {
+    throw result.ire;
+  }
+  if (result.__isset.ue) {
+    throw result.ue;
+  }
+  if (result.__isset.te) {
+    throw result.te;
+  }
+  return;
+}
+
+void CassandraClient::remove_counter(const std::string& key, const ColumnPath& path, const ConsistencyLevel::type consistency_level)
+{
+  send_remove_counter(key, path, consistency_level);
+  recv_remove_counter();
+}
+
+void CassandraClient::send_remove_counter(const std::string& key, const ColumnPath& path, const ConsistencyLevel::type consistency_level)
+{
+  int32_t cseqid = 0;
+  oprot_->writeMessageBegin("remove_counter", ::apache::thrift::protocol::T_CALL, cseqid);
+
+  Cassandra_remove_counter_pargs args;
+  args.key = &key;
+  args.path = &path;
+  args.consistency_level = &consistency_level;
+  args.write(oprot_);
+
+  oprot_->writeMessageEnd();
+  oprot_->getTransport()->flush();
+  oprot_->getTransport()->writeEnd();
+}
+
+void CassandraClient::recv_remove_counter()
+{
+
+  int32_t rseqid = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TMessageType mtype;
+
+  iprot_->readMessageBegin(fname, mtype, rseqid);
+  if (mtype == ::apache::thrift::protocol::T_EXCEPTION) {
+    ::apache::thrift::TApplicationException x;
+    x.read(iprot_);
+    iprot_->readMessageEnd();
+    iprot_->getTransport()->readEnd();
+    throw x;
+  }
+  if (mtype != ::apache::thrift::protocol::T_REPLY) {
+    iprot_->skip(::apache::thrift::protocol::T_STRUCT);
+    iprot_->readMessageEnd();
+    iprot_->getTransport()->readEnd();
+    throw ::apache::thrift::TApplicationException(::apache::thrift::TApplicationException::INVALID_MESSAGE_TYPE);
+  }
+  if (fname.compare("remove_counter") != 0) {
+    iprot_->skip(::apache::thrift::protocol::T_STRUCT);
+    iprot_->readMessageEnd();
+    iprot_->getTransport()->readEnd();
+    throw ::apache::thrift::TApplicationException(::apache::thrift::TApplicationException::WRONG_METHOD_NAME);
+  }
+  Cassandra_remove_counter_presult result;
   result.read(iprot_);
   iprot_->readMessageEnd();
   iprot_->getTransport()->readEnd();
@@ -7717,6 +8741,9 @@ void CassandraClient::recv_describe_splits(std::vector<std::string> & _return)
     // _return pointer has now been filled
     return;
   }
+  if (result.__isset.ire) {
+    throw result.ire;
+  }
   throw ::apache::thrift::TApplicationException(::apache::thrift::TApplicationException::MISSING_RESULT, "describe_splits failed: unknown result");
 }
 
@@ -7779,6 +8806,9 @@ void CassandraClient::recv_system_add_column_family(std::string& _return)
   }
   if (result.__isset.ire) {
     throw result.ire;
+  }
+  if (result.__isset.sde) {
+    throw result.sde;
   }
   throw ::apache::thrift::TApplicationException(::apache::thrift::TApplicationException::MISSING_RESULT, "system_add_column_family failed: unknown result");
 }
@@ -7843,6 +8873,9 @@ void CassandraClient::recv_system_drop_column_family(std::string& _return)
   if (result.__isset.ire) {
     throw result.ire;
   }
+  if (result.__isset.sde) {
+    throw result.sde;
+  }
   throw ::apache::thrift::TApplicationException(::apache::thrift::TApplicationException::MISSING_RESULT, "system_drop_column_family failed: unknown result");
 }
 
@@ -7905,6 +8938,9 @@ void CassandraClient::recv_system_add_keyspace(std::string& _return)
   }
   if (result.__isset.ire) {
     throw result.ire;
+  }
+  if (result.__isset.sde) {
+    throw result.sde;
   }
   throw ::apache::thrift::TApplicationException(::apache::thrift::TApplicationException::MISSING_RESULT, "system_add_keyspace failed: unknown result");
 }
@@ -7969,6 +9005,9 @@ void CassandraClient::recv_system_drop_keyspace(std::string& _return)
   if (result.__isset.ire) {
     throw result.ire;
   }
+  if (result.__isset.sde) {
+    throw result.sde;
+  }
   throw ::apache::thrift::TApplicationException(::apache::thrift::TApplicationException::MISSING_RESULT, "system_drop_keyspace failed: unknown result");
 }
 
@@ -8031,6 +9070,9 @@ void CassandraClient::recv_system_update_keyspace(std::string& _return)
   }
   if (result.__isset.ire) {
     throw result.ire;
+  }
+  if (result.__isset.sde) {
+    throw result.sde;
   }
   throw ::apache::thrift::TApplicationException(::apache::thrift::TApplicationException::MISSING_RESULT, "system_update_keyspace failed: unknown result");
 }
@@ -8095,7 +9137,83 @@ void CassandraClient::recv_system_update_column_family(std::string& _return)
   if (result.__isset.ire) {
     throw result.ire;
   }
+  if (result.__isset.sde) {
+    throw result.sde;
+  }
   throw ::apache::thrift::TApplicationException(::apache::thrift::TApplicationException::MISSING_RESULT, "system_update_column_family failed: unknown result");
+}
+
+void CassandraClient::execute_cql_query(CqlResult& _return, const std::string& query, const Compression::type compression)
+{
+  send_execute_cql_query(query, compression);
+  recv_execute_cql_query(_return);
+}
+
+void CassandraClient::send_execute_cql_query(const std::string& query, const Compression::type compression)
+{
+  int32_t cseqid = 0;
+  oprot_->writeMessageBegin("execute_cql_query", ::apache::thrift::protocol::T_CALL, cseqid);
+
+  Cassandra_execute_cql_query_pargs args;
+  args.query = &query;
+  args.compression = &compression;
+  args.write(oprot_);
+
+  oprot_->writeMessageEnd();
+  oprot_->getTransport()->flush();
+  oprot_->getTransport()->writeEnd();
+}
+
+void CassandraClient::recv_execute_cql_query(CqlResult& _return)
+{
+
+  int32_t rseqid = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TMessageType mtype;
+
+  iprot_->readMessageBegin(fname, mtype, rseqid);
+  if (mtype == ::apache::thrift::protocol::T_EXCEPTION) {
+    ::apache::thrift::TApplicationException x;
+    x.read(iprot_);
+    iprot_->readMessageEnd();
+    iprot_->getTransport()->readEnd();
+    throw x;
+  }
+  if (mtype != ::apache::thrift::protocol::T_REPLY) {
+    iprot_->skip(::apache::thrift::protocol::T_STRUCT);
+    iprot_->readMessageEnd();
+    iprot_->getTransport()->readEnd();
+    throw ::apache::thrift::TApplicationException(::apache::thrift::TApplicationException::INVALID_MESSAGE_TYPE);
+  }
+  if (fname.compare("execute_cql_query") != 0) {
+    iprot_->skip(::apache::thrift::protocol::T_STRUCT);
+    iprot_->readMessageEnd();
+    iprot_->getTransport()->readEnd();
+    throw ::apache::thrift::TApplicationException(::apache::thrift::TApplicationException::WRONG_METHOD_NAME);
+  }
+  Cassandra_execute_cql_query_presult result;
+  result.success = &_return;
+  result.read(iprot_);
+  iprot_->readMessageEnd();
+  iprot_->getTransport()->readEnd();
+
+  if (result.__isset.success) {
+    // _return pointer has now been filled
+    return;
+  }
+  if (result.__isset.ire) {
+    throw result.ire;
+  }
+  if (result.__isset.ue) {
+    throw result.ue;
+  }
+  if (result.__isset.te) {
+    throw result.te;
+  }
+  if (result.__isset.sde) {
+    throw result.sde;
+  }
+  throw ::apache::thrift::TApplicationException(::apache::thrift::TApplicationException::MISSING_RESULT, "execute_cql_query failed: unknown result");
 }
 
 bool CassandraProcessor::process(boost::shared_ptr< ::apache::thrift::protocol::TProtocol> piprot, boost::shared_ptr< ::apache::thrift::protocol::TProtocol> poprot) {
@@ -8504,6 +9622,42 @@ void CassandraProcessor::process_insert(int32_t seqid, ::apache::thrift::protoco
   oprot->getTransport()->writeEnd();
 }
 
+void CassandraProcessor::process_add(int32_t seqid, ::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot)
+{
+  Cassandra_add_args args;
+  args.read(iprot);
+  iprot->readMessageEnd();
+  iprot->getTransport()->readEnd();
+
+  Cassandra_add_result result;
+  try {
+    iface_->add(args.key, args.column_parent, args.column, args.consistency_level);
+  } catch (InvalidRequestException &ire) {
+    result.ire = ire;
+    result.__isset.ire = true;
+  } catch (UnavailableException &ue) {
+    result.ue = ue;
+    result.__isset.ue = true;
+  } catch (TimedOutException &te) {
+    result.te = te;
+    result.__isset.te = true;
+  } catch (const std::exception& e) {
+    ::apache::thrift::TApplicationException x(e.what());
+    oprot->writeMessageBegin("add", ::apache::thrift::protocol::T_EXCEPTION, seqid);
+    x.write(oprot);
+    oprot->writeMessageEnd();
+    oprot->getTransport()->flush();
+    oprot->getTransport()->writeEnd();
+    return;
+  }
+
+  oprot->writeMessageBegin("add", ::apache::thrift::protocol::T_REPLY, seqid);
+  result.write(oprot);
+  oprot->writeMessageEnd();
+  oprot->getTransport()->flush();
+  oprot->getTransport()->writeEnd();
+}
+
 void CassandraProcessor::process_remove(int32_t seqid, ::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot)
 {
   Cassandra_remove_args args;
@@ -8534,6 +9688,42 @@ void CassandraProcessor::process_remove(int32_t seqid, ::apache::thrift::protoco
   }
 
   oprot->writeMessageBegin("remove", ::apache::thrift::protocol::T_REPLY, seqid);
+  result.write(oprot);
+  oprot->writeMessageEnd();
+  oprot->getTransport()->flush();
+  oprot->getTransport()->writeEnd();
+}
+
+void CassandraProcessor::process_remove_counter(int32_t seqid, ::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot)
+{
+  Cassandra_remove_counter_args args;
+  args.read(iprot);
+  iprot->readMessageEnd();
+  iprot->getTransport()->readEnd();
+
+  Cassandra_remove_counter_result result;
+  try {
+    iface_->remove_counter(args.key, args.path, args.consistency_level);
+  } catch (InvalidRequestException &ire) {
+    result.ire = ire;
+    result.__isset.ire = true;
+  } catch (UnavailableException &ue) {
+    result.ue = ue;
+    result.__isset.ue = true;
+  } catch (TimedOutException &te) {
+    result.te = te;
+    result.__isset.te = true;
+  } catch (const std::exception& e) {
+    ::apache::thrift::TApplicationException x(e.what());
+    oprot->writeMessageBegin("remove_counter", ::apache::thrift::protocol::T_EXCEPTION, seqid);
+    x.write(oprot);
+    oprot->writeMessageEnd();
+    oprot->getTransport()->flush();
+    oprot->getTransport()->writeEnd();
+    return;
+  }
+
+  oprot->writeMessageBegin("remove_counter", ::apache::thrift::protocol::T_REPLY, seqid);
   result.write(oprot);
   oprot->writeMessageEnd();
   oprot->getTransport()->flush();
@@ -8859,6 +10049,9 @@ void CassandraProcessor::process_describe_splits(int32_t seqid, ::apache::thrift
   try {
     iface_->describe_splits(result.success, args.cfName, args.start_token, args.end_token, args.keys_per_split);
     result.__isset.success = true;
+  } catch (InvalidRequestException &ire) {
+    result.ire = ire;
+    result.__isset.ire = true;
   } catch (const std::exception& e) {
     ::apache::thrift::TApplicationException x(e.what());
     oprot->writeMessageBegin("describe_splits", ::apache::thrift::protocol::T_EXCEPTION, seqid);
@@ -8890,6 +10083,9 @@ void CassandraProcessor::process_system_add_column_family(int32_t seqid, ::apach
   } catch (InvalidRequestException &ire) {
     result.ire = ire;
     result.__isset.ire = true;
+  } catch (SchemaDisagreementException &sde) {
+    result.sde = sde;
+    result.__isset.sde = true;
   } catch (const std::exception& e) {
     ::apache::thrift::TApplicationException x(e.what());
     oprot->writeMessageBegin("system_add_column_family", ::apache::thrift::protocol::T_EXCEPTION, seqid);
@@ -8921,6 +10117,9 @@ void CassandraProcessor::process_system_drop_column_family(int32_t seqid, ::apac
   } catch (InvalidRequestException &ire) {
     result.ire = ire;
     result.__isset.ire = true;
+  } catch (SchemaDisagreementException &sde) {
+    result.sde = sde;
+    result.__isset.sde = true;
   } catch (const std::exception& e) {
     ::apache::thrift::TApplicationException x(e.what());
     oprot->writeMessageBegin("system_drop_column_family", ::apache::thrift::protocol::T_EXCEPTION, seqid);
@@ -8952,6 +10151,9 @@ void CassandraProcessor::process_system_add_keyspace(int32_t seqid, ::apache::th
   } catch (InvalidRequestException &ire) {
     result.ire = ire;
     result.__isset.ire = true;
+  } catch (SchemaDisagreementException &sde) {
+    result.sde = sde;
+    result.__isset.sde = true;
   } catch (const std::exception& e) {
     ::apache::thrift::TApplicationException x(e.what());
     oprot->writeMessageBegin("system_add_keyspace", ::apache::thrift::protocol::T_EXCEPTION, seqid);
@@ -8983,6 +10185,9 @@ void CassandraProcessor::process_system_drop_keyspace(int32_t seqid, ::apache::t
   } catch (InvalidRequestException &ire) {
     result.ire = ire;
     result.__isset.ire = true;
+  } catch (SchemaDisagreementException &sde) {
+    result.sde = sde;
+    result.__isset.sde = true;
   } catch (const std::exception& e) {
     ::apache::thrift::TApplicationException x(e.what());
     oprot->writeMessageBegin("system_drop_keyspace", ::apache::thrift::protocol::T_EXCEPTION, seqid);
@@ -9014,6 +10219,9 @@ void CassandraProcessor::process_system_update_keyspace(int32_t seqid, ::apache:
   } catch (InvalidRequestException &ire) {
     result.ire = ire;
     result.__isset.ire = true;
+  } catch (SchemaDisagreementException &sde) {
+    result.sde = sde;
+    result.__isset.sde = true;
   } catch (const std::exception& e) {
     ::apache::thrift::TApplicationException x(e.what());
     oprot->writeMessageBegin("system_update_keyspace", ::apache::thrift::protocol::T_EXCEPTION, seqid);
@@ -9045,6 +10253,9 @@ void CassandraProcessor::process_system_update_column_family(int32_t seqid, ::ap
   } catch (InvalidRequestException &ire) {
     result.ire = ire;
     result.__isset.ire = true;
+  } catch (SchemaDisagreementException &sde) {
+    result.sde = sde;
+    result.__isset.sde = true;
   } catch (const std::exception& e) {
     ::apache::thrift::TApplicationException x(e.what());
     oprot->writeMessageBegin("system_update_column_family", ::apache::thrift::protocol::T_EXCEPTION, seqid);
@@ -9056,6 +10267,46 @@ void CassandraProcessor::process_system_update_column_family(int32_t seqid, ::ap
   }
 
   oprot->writeMessageBegin("system_update_column_family", ::apache::thrift::protocol::T_REPLY, seqid);
+  result.write(oprot);
+  oprot->writeMessageEnd();
+  oprot->getTransport()->flush();
+  oprot->getTransport()->writeEnd();
+}
+
+void CassandraProcessor::process_execute_cql_query(int32_t seqid, ::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot)
+{
+  Cassandra_execute_cql_query_args args;
+  args.read(iprot);
+  iprot->readMessageEnd();
+  iprot->getTransport()->readEnd();
+
+  Cassandra_execute_cql_query_result result;
+  try {
+    iface_->execute_cql_query(result.success, args.query, args.compression);
+    result.__isset.success = true;
+  } catch (InvalidRequestException &ire) {
+    result.ire = ire;
+    result.__isset.ire = true;
+  } catch (UnavailableException &ue) {
+    result.ue = ue;
+    result.__isset.ue = true;
+  } catch (TimedOutException &te) {
+    result.te = te;
+    result.__isset.te = true;
+  } catch (SchemaDisagreementException &sde) {
+    result.sde = sde;
+    result.__isset.sde = true;
+  } catch (const std::exception& e) {
+    ::apache::thrift::TApplicationException x(e.what());
+    oprot->writeMessageBegin("execute_cql_query", ::apache::thrift::protocol::T_EXCEPTION, seqid);
+    x.write(oprot);
+    oprot->writeMessageEnd();
+    oprot->getTransport()->flush();
+    oprot->getTransport()->writeEnd();
+    return;
+  }
+
+  oprot->writeMessageBegin("execute_cql_query", ::apache::thrift::protocol::T_REPLY, seqid);
   result.write(oprot);
   oprot->writeMessageEnd();
   oprot->getTransport()->flush();

--- a/libgenthrift/Cassandra.h
+++ b/libgenthrift/Cassandra.h
@@ -24,7 +24,9 @@ class CassandraIf {
   virtual void get_range_slices(std::vector<KeySlice> & _return, const ColumnParent& column_parent, const SlicePredicate& predicate, const KeyRange& range, const ConsistencyLevel::type consistency_level) = 0;
   virtual void get_indexed_slices(std::vector<KeySlice> & _return, const ColumnParent& column_parent, const IndexClause& index_clause, const SlicePredicate& column_predicate, const ConsistencyLevel::type consistency_level) = 0;
   virtual void insert(const std::string& key, const ColumnParent& column_parent, const Column& column, const ConsistencyLevel::type consistency_level) = 0;
+  virtual void add(const std::string& key, const ColumnParent& column_parent, const CounterColumn& column, const ConsistencyLevel::type consistency_level) = 0;
   virtual void remove(const std::string& key, const ColumnPath& column_path, const int64_t timestamp, const ConsistencyLevel::type consistency_level) = 0;
+  virtual void remove_counter(const std::string& key, const ColumnPath& path, const ConsistencyLevel::type consistency_level) = 0;
   virtual void batch_mutate(const std::map<std::string, std::map<std::string, std::vector<Mutation> > > & mutation_map, const ConsistencyLevel::type consistency_level) = 0;
   virtual void truncate(const std::string& cfname) = 0;
   virtual void describe_schema_versions(std::map<std::string, std::vector<std::string> > & _return) = 0;
@@ -42,6 +44,7 @@ class CassandraIf {
   virtual void system_drop_keyspace(std::string& _return, const std::string& keyspace) = 0;
   virtual void system_update_keyspace(std::string& _return, const KsDef& ks_def) = 0;
   virtual void system_update_column_family(std::string& _return, const CfDef& cf_def) = 0;
+  virtual void execute_cql_query(CqlResult& _return, const std::string& query, const Compression::type compression) = 0;
 };
 
 class CassandraNull : virtual public CassandraIf {
@@ -78,7 +81,13 @@ class CassandraNull : virtual public CassandraIf {
   void insert(const std::string& /* key */, const ColumnParent& /* column_parent */, const Column& /* column */, const ConsistencyLevel::type /* consistency_level */) {
     return;
   }
+  void add(const std::string& /* key */, const ColumnParent& /* column_parent */, const CounterColumn& /* column */, const ConsistencyLevel::type /* consistency_level */) {
+    return;
+  }
   void remove(const std::string& /* key */, const ColumnPath& /* column_path */, const int64_t /* timestamp */, const ConsistencyLevel::type /* consistency_level */) {
+    return;
+  }
+  void remove_counter(const std::string& /* key */, const ColumnPath& /* path */, const ConsistencyLevel::type /* consistency_level */) {
     return;
   }
   void batch_mutate(const std::map<std::string, std::map<std::string, std::vector<Mutation> > > & /* mutation_map */, const ConsistencyLevel::type /* consistency_level */) {
@@ -130,6 +139,9 @@ class CassandraNull : virtual public CassandraIf {
     return;
   }
   void system_update_column_family(std::string& /* _return */, const CfDef& /* cf_def */) {
+    return;
+  }
+  void execute_cql_query(CqlResult& /* _return */, const std::string& /* query */, const Compression::type /* compression */) {
     return;
   }
 };
@@ -1332,6 +1344,126 @@ class Cassandra_insert_presult {
 
 };
 
+
+class Cassandra_add_args {
+ public:
+
+  Cassandra_add_args() : key("") {
+    consistency_level = (ConsistencyLevel::type)1;
+
+  }
+
+  virtual ~Cassandra_add_args() throw() {}
+
+  std::string key;
+  ColumnParent column_parent;
+  CounterColumn column;
+  ConsistencyLevel::type consistency_level;
+
+  bool operator == (const Cassandra_add_args & rhs) const
+  {
+    if (!(key == rhs.key))
+      return false;
+    if (!(column_parent == rhs.column_parent))
+      return false;
+    if (!(column == rhs.column))
+      return false;
+    if (!(consistency_level == rhs.consistency_level))
+      return false;
+    return true;
+  }
+  bool operator != (const Cassandra_add_args &rhs) const {
+    return !(*this == rhs);
+  }
+
+  bool operator < (const Cassandra_add_args & ) const;
+
+  uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
+  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
+
+};
+
+
+class Cassandra_add_pargs {
+ public:
+
+
+  virtual ~Cassandra_add_pargs() throw() {}
+
+  const std::string* key;
+  const ColumnParent* column_parent;
+  const CounterColumn* column;
+  const ConsistencyLevel::type* consistency_level;
+
+  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
+
+};
+
+typedef struct _Cassandra_add_result__isset {
+  _Cassandra_add_result__isset() : ire(false), ue(false), te(false) {}
+  bool ire;
+  bool ue;
+  bool te;
+} _Cassandra_add_result__isset;
+
+class Cassandra_add_result {
+ public:
+
+  Cassandra_add_result() {
+  }
+
+  virtual ~Cassandra_add_result() throw() {}
+
+  InvalidRequestException ire;
+  UnavailableException ue;
+  TimedOutException te;
+
+  _Cassandra_add_result__isset __isset;
+
+  bool operator == (const Cassandra_add_result & rhs) const
+  {
+    if (!(ire == rhs.ire))
+      return false;
+    if (!(ue == rhs.ue))
+      return false;
+    if (!(te == rhs.te))
+      return false;
+    return true;
+  }
+  bool operator != (const Cassandra_add_result &rhs) const {
+    return !(*this == rhs);
+  }
+
+  bool operator < (const Cassandra_add_result & ) const;
+
+  uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
+  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
+
+};
+
+typedef struct _Cassandra_add_presult__isset {
+  _Cassandra_add_presult__isset() : ire(false), ue(false), te(false) {}
+  bool ire;
+  bool ue;
+  bool te;
+} _Cassandra_add_presult__isset;
+
+class Cassandra_add_presult {
+ public:
+
+
+  virtual ~Cassandra_add_presult() throw() {}
+
+  InvalidRequestException ire;
+  UnavailableException ue;
+  TimedOutException te;
+
+  _Cassandra_add_presult__isset __isset;
+
+  uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
+
+};
+
 typedef struct _Cassandra_remove_args__isset {
   _Cassandra_remove_args__isset() : consistency_level(false) {}
   bool consistency_level;
@@ -1453,6 +1585,122 @@ class Cassandra_remove_presult {
   TimedOutException te;
 
   _Cassandra_remove_presult__isset __isset;
+
+  uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
+
+};
+
+
+class Cassandra_remove_counter_args {
+ public:
+
+  Cassandra_remove_counter_args() : key("") {
+    consistency_level = (ConsistencyLevel::type)1;
+
+  }
+
+  virtual ~Cassandra_remove_counter_args() throw() {}
+
+  std::string key;
+  ColumnPath path;
+  ConsistencyLevel::type consistency_level;
+
+  bool operator == (const Cassandra_remove_counter_args & rhs) const
+  {
+    if (!(key == rhs.key))
+      return false;
+    if (!(path == rhs.path))
+      return false;
+    if (!(consistency_level == rhs.consistency_level))
+      return false;
+    return true;
+  }
+  bool operator != (const Cassandra_remove_counter_args &rhs) const {
+    return !(*this == rhs);
+  }
+
+  bool operator < (const Cassandra_remove_counter_args & ) const;
+
+  uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
+  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
+
+};
+
+
+class Cassandra_remove_counter_pargs {
+ public:
+
+
+  virtual ~Cassandra_remove_counter_pargs() throw() {}
+
+  const std::string* key;
+  const ColumnPath* path;
+  const ConsistencyLevel::type* consistency_level;
+
+  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
+
+};
+
+typedef struct _Cassandra_remove_counter_result__isset {
+  _Cassandra_remove_counter_result__isset() : ire(false), ue(false), te(false) {}
+  bool ire;
+  bool ue;
+  bool te;
+} _Cassandra_remove_counter_result__isset;
+
+class Cassandra_remove_counter_result {
+ public:
+
+  Cassandra_remove_counter_result() {
+  }
+
+  virtual ~Cassandra_remove_counter_result() throw() {}
+
+  InvalidRequestException ire;
+  UnavailableException ue;
+  TimedOutException te;
+
+  _Cassandra_remove_counter_result__isset __isset;
+
+  bool operator == (const Cassandra_remove_counter_result & rhs) const
+  {
+    if (!(ire == rhs.ire))
+      return false;
+    if (!(ue == rhs.ue))
+      return false;
+    if (!(te == rhs.te))
+      return false;
+    return true;
+  }
+  bool operator != (const Cassandra_remove_counter_result &rhs) const {
+    return !(*this == rhs);
+  }
+
+  bool operator < (const Cassandra_remove_counter_result & ) const;
+
+  uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
+  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
+
+};
+
+typedef struct _Cassandra_remove_counter_presult__isset {
+  _Cassandra_remove_counter_presult__isset() : ire(false), ue(false), te(false) {}
+  bool ire;
+  bool ue;
+  bool te;
+} _Cassandra_remove_counter_presult__isset;
+
+class Cassandra_remove_counter_presult {
+ public:
+
+
+  virtual ~Cassandra_remove_counter_presult() throw() {}
+
+  InvalidRequestException ire;
+  UnavailableException ue;
+  TimedOutException te;
+
+  _Cassandra_remove_counter_presult__isset __isset;
 
   uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
 
@@ -2482,8 +2730,9 @@ class Cassandra_describe_splits_pargs {
 };
 
 typedef struct _Cassandra_describe_splits_result__isset {
-  _Cassandra_describe_splits_result__isset() : success(false) {}
+  _Cassandra_describe_splits_result__isset() : success(false), ire(false) {}
   bool success;
+  bool ire;
 } _Cassandra_describe_splits_result__isset;
 
 class Cassandra_describe_splits_result {
@@ -2495,12 +2744,15 @@ class Cassandra_describe_splits_result {
   virtual ~Cassandra_describe_splits_result() throw() {}
 
   std::vector<std::string>  success;
+  InvalidRequestException ire;
 
   _Cassandra_describe_splits_result__isset __isset;
 
   bool operator == (const Cassandra_describe_splits_result & rhs) const
   {
     if (!(success == rhs.success))
+      return false;
+    if (!(ire == rhs.ire))
       return false;
     return true;
   }
@@ -2516,8 +2768,9 @@ class Cassandra_describe_splits_result {
 };
 
 typedef struct _Cassandra_describe_splits_presult__isset {
-  _Cassandra_describe_splits_presult__isset() : success(false) {}
+  _Cassandra_describe_splits_presult__isset() : success(false), ire(false) {}
   bool success;
+  bool ire;
 } _Cassandra_describe_splits_presult__isset;
 
 class Cassandra_describe_splits_presult {
@@ -2527,6 +2780,7 @@ class Cassandra_describe_splits_presult {
   virtual ~Cassandra_describe_splits_presult() throw() {}
 
   std::vector<std::string> * success;
+  InvalidRequestException ire;
 
   _Cassandra_describe_splits_presult__isset __isset;
 
@@ -2576,9 +2830,10 @@ class Cassandra_system_add_column_family_pargs {
 };
 
 typedef struct _Cassandra_system_add_column_family_result__isset {
-  _Cassandra_system_add_column_family_result__isset() : success(false), ire(false) {}
+  _Cassandra_system_add_column_family_result__isset() : success(false), ire(false), sde(false) {}
   bool success;
   bool ire;
+  bool sde;
 } _Cassandra_system_add_column_family_result__isset;
 
 class Cassandra_system_add_column_family_result {
@@ -2591,6 +2846,7 @@ class Cassandra_system_add_column_family_result {
 
   std::string success;
   InvalidRequestException ire;
+  SchemaDisagreementException sde;
 
   _Cassandra_system_add_column_family_result__isset __isset;
 
@@ -2599,6 +2855,8 @@ class Cassandra_system_add_column_family_result {
     if (!(success == rhs.success))
       return false;
     if (!(ire == rhs.ire))
+      return false;
+    if (!(sde == rhs.sde))
       return false;
     return true;
   }
@@ -2614,9 +2872,10 @@ class Cassandra_system_add_column_family_result {
 };
 
 typedef struct _Cassandra_system_add_column_family_presult__isset {
-  _Cassandra_system_add_column_family_presult__isset() : success(false), ire(false) {}
+  _Cassandra_system_add_column_family_presult__isset() : success(false), ire(false), sde(false) {}
   bool success;
   bool ire;
+  bool sde;
 } _Cassandra_system_add_column_family_presult__isset;
 
 class Cassandra_system_add_column_family_presult {
@@ -2627,6 +2886,7 @@ class Cassandra_system_add_column_family_presult {
 
   std::string* success;
   InvalidRequestException ire;
+  SchemaDisagreementException sde;
 
   _Cassandra_system_add_column_family_presult__isset __isset;
 
@@ -2676,9 +2936,10 @@ class Cassandra_system_drop_column_family_pargs {
 };
 
 typedef struct _Cassandra_system_drop_column_family_result__isset {
-  _Cassandra_system_drop_column_family_result__isset() : success(false), ire(false) {}
+  _Cassandra_system_drop_column_family_result__isset() : success(false), ire(false), sde(false) {}
   bool success;
   bool ire;
+  bool sde;
 } _Cassandra_system_drop_column_family_result__isset;
 
 class Cassandra_system_drop_column_family_result {
@@ -2691,6 +2952,7 @@ class Cassandra_system_drop_column_family_result {
 
   std::string success;
   InvalidRequestException ire;
+  SchemaDisagreementException sde;
 
   _Cassandra_system_drop_column_family_result__isset __isset;
 
@@ -2699,6 +2961,8 @@ class Cassandra_system_drop_column_family_result {
     if (!(success == rhs.success))
       return false;
     if (!(ire == rhs.ire))
+      return false;
+    if (!(sde == rhs.sde))
       return false;
     return true;
   }
@@ -2714,9 +2978,10 @@ class Cassandra_system_drop_column_family_result {
 };
 
 typedef struct _Cassandra_system_drop_column_family_presult__isset {
-  _Cassandra_system_drop_column_family_presult__isset() : success(false), ire(false) {}
+  _Cassandra_system_drop_column_family_presult__isset() : success(false), ire(false), sde(false) {}
   bool success;
   bool ire;
+  bool sde;
 } _Cassandra_system_drop_column_family_presult__isset;
 
 class Cassandra_system_drop_column_family_presult {
@@ -2727,6 +2992,7 @@ class Cassandra_system_drop_column_family_presult {
 
   std::string* success;
   InvalidRequestException ire;
+  SchemaDisagreementException sde;
 
   _Cassandra_system_drop_column_family_presult__isset __isset;
 
@@ -2776,9 +3042,10 @@ class Cassandra_system_add_keyspace_pargs {
 };
 
 typedef struct _Cassandra_system_add_keyspace_result__isset {
-  _Cassandra_system_add_keyspace_result__isset() : success(false), ire(false) {}
+  _Cassandra_system_add_keyspace_result__isset() : success(false), ire(false), sde(false) {}
   bool success;
   bool ire;
+  bool sde;
 } _Cassandra_system_add_keyspace_result__isset;
 
 class Cassandra_system_add_keyspace_result {
@@ -2791,6 +3058,7 @@ class Cassandra_system_add_keyspace_result {
 
   std::string success;
   InvalidRequestException ire;
+  SchemaDisagreementException sde;
 
   _Cassandra_system_add_keyspace_result__isset __isset;
 
@@ -2799,6 +3067,8 @@ class Cassandra_system_add_keyspace_result {
     if (!(success == rhs.success))
       return false;
     if (!(ire == rhs.ire))
+      return false;
+    if (!(sde == rhs.sde))
       return false;
     return true;
   }
@@ -2814,9 +3084,10 @@ class Cassandra_system_add_keyspace_result {
 };
 
 typedef struct _Cassandra_system_add_keyspace_presult__isset {
-  _Cassandra_system_add_keyspace_presult__isset() : success(false), ire(false) {}
+  _Cassandra_system_add_keyspace_presult__isset() : success(false), ire(false), sde(false) {}
   bool success;
   bool ire;
+  bool sde;
 } _Cassandra_system_add_keyspace_presult__isset;
 
 class Cassandra_system_add_keyspace_presult {
@@ -2827,6 +3098,7 @@ class Cassandra_system_add_keyspace_presult {
 
   std::string* success;
   InvalidRequestException ire;
+  SchemaDisagreementException sde;
 
   _Cassandra_system_add_keyspace_presult__isset __isset;
 
@@ -2876,9 +3148,10 @@ class Cassandra_system_drop_keyspace_pargs {
 };
 
 typedef struct _Cassandra_system_drop_keyspace_result__isset {
-  _Cassandra_system_drop_keyspace_result__isset() : success(false), ire(false) {}
+  _Cassandra_system_drop_keyspace_result__isset() : success(false), ire(false), sde(false) {}
   bool success;
   bool ire;
+  bool sde;
 } _Cassandra_system_drop_keyspace_result__isset;
 
 class Cassandra_system_drop_keyspace_result {
@@ -2891,6 +3164,7 @@ class Cassandra_system_drop_keyspace_result {
 
   std::string success;
   InvalidRequestException ire;
+  SchemaDisagreementException sde;
 
   _Cassandra_system_drop_keyspace_result__isset __isset;
 
@@ -2899,6 +3173,8 @@ class Cassandra_system_drop_keyspace_result {
     if (!(success == rhs.success))
       return false;
     if (!(ire == rhs.ire))
+      return false;
+    if (!(sde == rhs.sde))
       return false;
     return true;
   }
@@ -2914,9 +3190,10 @@ class Cassandra_system_drop_keyspace_result {
 };
 
 typedef struct _Cassandra_system_drop_keyspace_presult__isset {
-  _Cassandra_system_drop_keyspace_presult__isset() : success(false), ire(false) {}
+  _Cassandra_system_drop_keyspace_presult__isset() : success(false), ire(false), sde(false) {}
   bool success;
   bool ire;
+  bool sde;
 } _Cassandra_system_drop_keyspace_presult__isset;
 
 class Cassandra_system_drop_keyspace_presult {
@@ -2927,6 +3204,7 @@ class Cassandra_system_drop_keyspace_presult {
 
   std::string* success;
   InvalidRequestException ire;
+  SchemaDisagreementException sde;
 
   _Cassandra_system_drop_keyspace_presult__isset __isset;
 
@@ -2976,9 +3254,10 @@ class Cassandra_system_update_keyspace_pargs {
 };
 
 typedef struct _Cassandra_system_update_keyspace_result__isset {
-  _Cassandra_system_update_keyspace_result__isset() : success(false), ire(false) {}
+  _Cassandra_system_update_keyspace_result__isset() : success(false), ire(false), sde(false) {}
   bool success;
   bool ire;
+  bool sde;
 } _Cassandra_system_update_keyspace_result__isset;
 
 class Cassandra_system_update_keyspace_result {
@@ -2991,6 +3270,7 @@ class Cassandra_system_update_keyspace_result {
 
   std::string success;
   InvalidRequestException ire;
+  SchemaDisagreementException sde;
 
   _Cassandra_system_update_keyspace_result__isset __isset;
 
@@ -2999,6 +3279,8 @@ class Cassandra_system_update_keyspace_result {
     if (!(success == rhs.success))
       return false;
     if (!(ire == rhs.ire))
+      return false;
+    if (!(sde == rhs.sde))
       return false;
     return true;
   }
@@ -3014,9 +3296,10 @@ class Cassandra_system_update_keyspace_result {
 };
 
 typedef struct _Cassandra_system_update_keyspace_presult__isset {
-  _Cassandra_system_update_keyspace_presult__isset() : success(false), ire(false) {}
+  _Cassandra_system_update_keyspace_presult__isset() : success(false), ire(false), sde(false) {}
   bool success;
   bool ire;
+  bool sde;
 } _Cassandra_system_update_keyspace_presult__isset;
 
 class Cassandra_system_update_keyspace_presult {
@@ -3027,6 +3310,7 @@ class Cassandra_system_update_keyspace_presult {
 
   std::string* success;
   InvalidRequestException ire;
+  SchemaDisagreementException sde;
 
   _Cassandra_system_update_keyspace_presult__isset __isset;
 
@@ -3076,9 +3360,10 @@ class Cassandra_system_update_column_family_pargs {
 };
 
 typedef struct _Cassandra_system_update_column_family_result__isset {
-  _Cassandra_system_update_column_family_result__isset() : success(false), ire(false) {}
+  _Cassandra_system_update_column_family_result__isset() : success(false), ire(false), sde(false) {}
   bool success;
   bool ire;
+  bool sde;
 } _Cassandra_system_update_column_family_result__isset;
 
 class Cassandra_system_update_column_family_result {
@@ -3091,6 +3376,7 @@ class Cassandra_system_update_column_family_result {
 
   std::string success;
   InvalidRequestException ire;
+  SchemaDisagreementException sde;
 
   _Cassandra_system_update_column_family_result__isset __isset;
 
@@ -3099,6 +3385,8 @@ class Cassandra_system_update_column_family_result {
     if (!(success == rhs.success))
       return false;
     if (!(ire == rhs.ire))
+      return false;
+    if (!(sde == rhs.sde))
       return false;
     return true;
   }
@@ -3114,9 +3402,10 @@ class Cassandra_system_update_column_family_result {
 };
 
 typedef struct _Cassandra_system_update_column_family_presult__isset {
-  _Cassandra_system_update_column_family_presult__isset() : success(false), ire(false) {}
+  _Cassandra_system_update_column_family_presult__isset() : success(false), ire(false), sde(false) {}
   bool success;
   bool ire;
+  bool sde;
 } _Cassandra_system_update_column_family_presult__isset;
 
 class Cassandra_system_update_column_family_presult {
@@ -3127,8 +3416,131 @@ class Cassandra_system_update_column_family_presult {
 
   std::string* success;
   InvalidRequestException ire;
+  SchemaDisagreementException sde;
 
   _Cassandra_system_update_column_family_presult__isset __isset;
+
+  uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
+
+};
+
+
+class Cassandra_execute_cql_query_args {
+ public:
+
+  Cassandra_execute_cql_query_args() : query("") {
+  }
+
+  virtual ~Cassandra_execute_cql_query_args() throw() {}
+
+  std::string query;
+  Compression::type compression;
+
+  bool operator == (const Cassandra_execute_cql_query_args & rhs) const
+  {
+    if (!(query == rhs.query))
+      return false;
+    if (!(compression == rhs.compression))
+      return false;
+    return true;
+  }
+  bool operator != (const Cassandra_execute_cql_query_args &rhs) const {
+    return !(*this == rhs);
+  }
+
+  bool operator < (const Cassandra_execute_cql_query_args & ) const;
+
+  uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
+  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
+
+};
+
+
+class Cassandra_execute_cql_query_pargs {
+ public:
+
+
+  virtual ~Cassandra_execute_cql_query_pargs() throw() {}
+
+  const std::string* query;
+  const Compression::type* compression;
+
+  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
+
+};
+
+typedef struct _Cassandra_execute_cql_query_result__isset {
+  _Cassandra_execute_cql_query_result__isset() : success(false), ire(false), ue(false), te(false), sde(false) {}
+  bool success;
+  bool ire;
+  bool ue;
+  bool te;
+  bool sde;
+} _Cassandra_execute_cql_query_result__isset;
+
+class Cassandra_execute_cql_query_result {
+ public:
+
+  Cassandra_execute_cql_query_result() {
+  }
+
+  virtual ~Cassandra_execute_cql_query_result() throw() {}
+
+  CqlResult success;
+  InvalidRequestException ire;
+  UnavailableException ue;
+  TimedOutException te;
+  SchemaDisagreementException sde;
+
+  _Cassandra_execute_cql_query_result__isset __isset;
+
+  bool operator == (const Cassandra_execute_cql_query_result & rhs) const
+  {
+    if (!(success == rhs.success))
+      return false;
+    if (!(ire == rhs.ire))
+      return false;
+    if (!(ue == rhs.ue))
+      return false;
+    if (!(te == rhs.te))
+      return false;
+    if (!(sde == rhs.sde))
+      return false;
+    return true;
+  }
+  bool operator != (const Cassandra_execute_cql_query_result &rhs) const {
+    return !(*this == rhs);
+  }
+
+  bool operator < (const Cassandra_execute_cql_query_result & ) const;
+
+  uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
+  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
+
+};
+
+typedef struct _Cassandra_execute_cql_query_presult__isset {
+  _Cassandra_execute_cql_query_presult__isset() : success(false), ire(false), ue(false), te(false), sde(false) {}
+  bool success;
+  bool ire;
+  bool ue;
+  bool te;
+  bool sde;
+} _Cassandra_execute_cql_query_presult__isset;
+
+class Cassandra_execute_cql_query_presult {
+ public:
+
+
+  virtual ~Cassandra_execute_cql_query_presult() throw() {}
+
+  CqlResult* success;
+  InvalidRequestException ire;
+  UnavailableException ue;
+  TimedOutException te;
+  SchemaDisagreementException sde;
+
+  _Cassandra_execute_cql_query_presult__isset __isset;
 
   uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
 
@@ -3184,9 +3596,15 @@ class CassandraClient : virtual public CassandraIf {
   void insert(const std::string& key, const ColumnParent& column_parent, const Column& column, const ConsistencyLevel::type consistency_level);
   void send_insert(const std::string& key, const ColumnParent& column_parent, const Column& column, const ConsistencyLevel::type consistency_level);
   void recv_insert();
+  void add(const std::string& key, const ColumnParent& column_parent, const CounterColumn& column, const ConsistencyLevel::type consistency_level);
+  void send_add(const std::string& key, const ColumnParent& column_parent, const CounterColumn& column, const ConsistencyLevel::type consistency_level);
+  void recv_add();
   void remove(const std::string& key, const ColumnPath& column_path, const int64_t timestamp, const ConsistencyLevel::type consistency_level);
   void send_remove(const std::string& key, const ColumnPath& column_path, const int64_t timestamp, const ConsistencyLevel::type consistency_level);
   void recv_remove();
+  void remove_counter(const std::string& key, const ColumnPath& path, const ConsistencyLevel::type consistency_level);
+  void send_remove_counter(const std::string& key, const ColumnPath& path, const ConsistencyLevel::type consistency_level);
+  void recv_remove_counter();
   void batch_mutate(const std::map<std::string, std::map<std::string, std::vector<Mutation> > > & mutation_map, const ConsistencyLevel::type consistency_level);
   void send_batch_mutate(const std::map<std::string, std::map<std::string, std::vector<Mutation> > > & mutation_map, const ConsistencyLevel::type consistency_level);
   void recv_batch_mutate();
@@ -3238,6 +3656,9 @@ class CassandraClient : virtual public CassandraIf {
   void system_update_column_family(std::string& _return, const CfDef& cf_def);
   void send_system_update_column_family(const CfDef& cf_def);
   void recv_system_update_column_family(std::string& _return);
+  void execute_cql_query(CqlResult& _return, const std::string& query, const Compression::type compression);
+  void send_execute_cql_query(const std::string& query, const Compression::type compression);
+  void recv_execute_cql_query(CqlResult& _return);
  protected:
   boost::shared_ptr< ::apache::thrift::protocol::TProtocol> piprot_;
   boost::shared_ptr< ::apache::thrift::protocol::TProtocol> poprot_;
@@ -3261,7 +3682,9 @@ class CassandraProcessor : virtual public ::apache::thrift::TProcessor {
   void process_get_range_slices(int32_t seqid, ::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot);
   void process_get_indexed_slices(int32_t seqid, ::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot);
   void process_insert(int32_t seqid, ::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot);
+  void process_add(int32_t seqid, ::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot);
   void process_remove(int32_t seqid, ::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot);
+  void process_remove_counter(int32_t seqid, ::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot);
   void process_batch_mutate(int32_t seqid, ::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot);
   void process_truncate(int32_t seqid, ::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot);
   void process_describe_schema_versions(int32_t seqid, ::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot);
@@ -3279,6 +3702,7 @@ class CassandraProcessor : virtual public ::apache::thrift::TProcessor {
   void process_system_drop_keyspace(int32_t seqid, ::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot);
   void process_system_update_keyspace(int32_t seqid, ::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot);
   void process_system_update_column_family(int32_t seqid, ::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot);
+  void process_execute_cql_query(int32_t seqid, ::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot);
  public:
   CassandraProcessor(boost::shared_ptr<CassandraIf> iface) :
     iface_(iface) {
@@ -3292,7 +3716,9 @@ class CassandraProcessor : virtual public ::apache::thrift::TProcessor {
     processMap_["get_range_slices"] = &CassandraProcessor::process_get_range_slices;
     processMap_["get_indexed_slices"] = &CassandraProcessor::process_get_indexed_slices;
     processMap_["insert"] = &CassandraProcessor::process_insert;
+    processMap_["add"] = &CassandraProcessor::process_add;
     processMap_["remove"] = &CassandraProcessor::process_remove;
+    processMap_["remove_counter"] = &CassandraProcessor::process_remove_counter;
     processMap_["batch_mutate"] = &CassandraProcessor::process_batch_mutate;
     processMap_["truncate"] = &CassandraProcessor::process_truncate;
     processMap_["describe_schema_versions"] = &CassandraProcessor::process_describe_schema_versions;
@@ -3310,6 +3736,7 @@ class CassandraProcessor : virtual public ::apache::thrift::TProcessor {
     processMap_["system_drop_keyspace"] = &CassandraProcessor::process_system_drop_keyspace;
     processMap_["system_update_keyspace"] = &CassandraProcessor::process_system_update_keyspace;
     processMap_["system_update_column_family"] = &CassandraProcessor::process_system_update_column_family;
+    processMap_["execute_cql_query"] = &CassandraProcessor::process_execute_cql_query;
   }
 
   virtual bool process(boost::shared_ptr< ::apache::thrift::protocol::TProtocol> piprot, boost::shared_ptr< ::apache::thrift::protocol::TProtocol> poprot);
@@ -3432,10 +3859,24 @@ class CassandraMultiface : virtual public CassandraIf {
     }
   }
 
+  void add(const std::string& key, const ColumnParent& column_parent, const CounterColumn& column, const ConsistencyLevel::type consistency_level) {
+    uint32_t sz = ifaces_.size();
+    for (uint32_t i = 0; i < sz; ++i) {
+      ifaces_[i]->add(key, column_parent, column, consistency_level);
+    }
+  }
+
   void remove(const std::string& key, const ColumnPath& column_path, const int64_t timestamp, const ConsistencyLevel::type consistency_level) {
     uint32_t sz = ifaces_.size();
     for (uint32_t i = 0; i < sz; ++i) {
       ifaces_[i]->remove(key, column_path, timestamp, consistency_level);
+    }
+  }
+
+  void remove_counter(const std::string& key, const ColumnPath& path, const ConsistencyLevel::type consistency_level) {
+    uint32_t sz = ifaces_.size();
+    for (uint32_t i = 0; i < sz; ++i) {
+      ifaces_[i]->remove_counter(key, path, consistency_level);
     }
   }
 
@@ -3629,6 +4070,18 @@ class CassandraMultiface : virtual public CassandraIf {
         return;
       } else {
         ifaces_[i]->system_update_column_family(_return, cf_def);
+      }
+    }
+  }
+
+  void execute_cql_query(CqlResult& _return, const std::string& query, const Compression::type compression) {
+    uint32_t sz = ifaces_.size();
+    for (uint32_t i = 0; i < sz; ++i) {
+      if (i == sz - 1) {
+        ifaces_[i]->execute_cql_query(_return, query, compression);
+        return;
+      } else {
+        ifaces_[i]->execute_cql_query(_return, query, compression);
       }
     }
   }

--- a/libgenthrift/Cassandra_server.skeleton.cpp
+++ b/libgenthrift/Cassandra_server.skeleton.cpp
@@ -72,9 +72,19 @@ class CassandraHandler : virtual public CassandraIf {
     printf("insert\n");
   }
 
+  void add(const std::string& key, const ColumnParent& column_parent, const CounterColumn& column, const ConsistencyLevel::type consistency_level) {
+    // Your implementation goes here
+    printf("add\n");
+  }
+
   void remove(const std::string& key, const ColumnPath& column_path, const int64_t timestamp, const ConsistencyLevel::type consistency_level) {
     // Your implementation goes here
     printf("remove\n");
+  }
+
+  void remove_counter(const std::string& key, const ColumnPath& path, const ConsistencyLevel::type consistency_level) {
+    // Your implementation goes here
+    printf("remove_counter\n");
   }
 
   void batch_mutate(const std::map<std::string, std::map<std::string, std::vector<Mutation> > > & mutation_map, const ConsistencyLevel::type consistency_level) {
@@ -160,6 +170,11 @@ class CassandraHandler : virtual public CassandraIf {
   void system_update_column_family(std::string& _return, const CfDef& cf_def) {
     // Your implementation goes here
     printf("system_update_column_family\n");
+  }
+
+  void execute_cql_query(CqlResult& _return, const std::string& query, const Compression::type compression) {
+    // Your implementation goes here
+    printf("execute_cql_query\n");
   }
 
 };

--- a/libgenthrift/cassandra_constants.cpp
+++ b/libgenthrift/cassandra_constants.cpp
@@ -10,7 +10,7 @@ namespace org { namespace apache { namespace cassandra {
 const cassandraConstants g_cassandra_constants;
 
 cassandraConstants::cassandraConstants() {
-  VERSION = "19.4.0";
+  VERSION = "19.10.0";
 
 }
 

--- a/libgenthrift/cassandra_constants.h
+++ b/libgenthrift/cassandra_constants.h
@@ -6,7 +6,9 @@
 #ifndef cassandra_CONSTANTS_H
 #define cassandra_CONSTANTS_H
 
-#include <string>
+#include "cassandra_types.h"
+
+#undef VERSION
 
 namespace org { namespace apache { namespace cassandra {
 

--- a/libgenthrift/cassandra_types.cpp
+++ b/libgenthrift/cassandra_types.cpp
@@ -7,8 +7,8 @@
 
 namespace org { namespace apache { namespace cassandra {
 
-const char* Column::ascii_fingerprint = "AFF5A2690BB9979816507B2F6BD21062";
-const uint8_t Column::binary_fingerprint[16] = {0xAF,0xF5,0xA2,0x69,0x0B,0xB9,0x97,0x98,0x16,0x50,0x7B,0x2F,0x6B,0xD2,0x10,0x62};
+const char* Column::ascii_fingerprint = "3EE0E1C5C844001B62F08125068292CC";
+const uint8_t Column::binary_fingerprint[16] = {0x3E,0xE0,0xE1,0xC5,0xC8,0x44,0x00,0x1B,0x62,0xF0,0x81,0x25,0x06,0x82,0x92,0xCC};
 
 uint32_t Column::read(::apache::thrift::protocol::TProtocol* iprot) {
 
@@ -22,8 +22,6 @@ uint32_t Column::read(::apache::thrift::protocol::TProtocol* iprot) {
   using ::apache::thrift::protocol::TProtocolException;
 
   bool isset_name = false;
-  bool isset_value = false;
-  bool isset_timestamp = false;
 
   while (true)
   {
@@ -44,7 +42,7 @@ uint32_t Column::read(::apache::thrift::protocol::TProtocol* iprot) {
       case 2:
         if (ftype == ::apache::thrift::protocol::T_STRING) {
           xfer += iprot->readBinary(this->value);
-          isset_value = true;
+          this->__isset.value = true;
         } else {
           xfer += iprot->skip(ftype);
         }
@@ -52,7 +50,7 @@ uint32_t Column::read(::apache::thrift::protocol::TProtocol* iprot) {
       case 3:
         if (ftype == ::apache::thrift::protocol::T_I64) {
           xfer += iprot->readI64(this->timestamp);
-          isset_timestamp = true;
+          this->__isset.timestamp = true;
         } else {
           xfer += iprot->skip(ftype);
         }
@@ -76,10 +74,6 @@ uint32_t Column::read(::apache::thrift::protocol::TProtocol* iprot) {
 
   if (!isset_name)
     throw TProtocolException(TProtocolException::INVALID_DATA);
-  if (!isset_value)
-    throw TProtocolException(TProtocolException::INVALID_DATA);
-  if (!isset_timestamp)
-    throw TProtocolException(TProtocolException::INVALID_DATA);
   return xfer;
 }
 
@@ -89,12 +83,16 @@ uint32_t Column::write(::apache::thrift::protocol::TProtocol* oprot) const {
   xfer += oprot->writeFieldBegin("name", ::apache::thrift::protocol::T_STRING, 1);
   xfer += oprot->writeBinary(this->name);
   xfer += oprot->writeFieldEnd();
-  xfer += oprot->writeFieldBegin("value", ::apache::thrift::protocol::T_STRING, 2);
-  xfer += oprot->writeBinary(this->value);
-  xfer += oprot->writeFieldEnd();
-  xfer += oprot->writeFieldBegin("timestamp", ::apache::thrift::protocol::T_I64, 3);
-  xfer += oprot->writeI64(this->timestamp);
-  xfer += oprot->writeFieldEnd();
+  if (this->__isset.value) {
+    xfer += oprot->writeFieldBegin("value", ::apache::thrift::protocol::T_STRING, 2);
+    xfer += oprot->writeBinary(this->value);
+    xfer += oprot->writeFieldEnd();
+  }
+  if (this->__isset.timestamp) {
+    xfer += oprot->writeFieldBegin("timestamp", ::apache::thrift::protocol::T_I64, 3);
+    xfer += oprot->writeI64(this->timestamp);
+    xfer += oprot->writeFieldEnd();
+  }
   if (this->__isset.ttl) {
     xfer += oprot->writeFieldBegin("ttl", ::apache::thrift::protocol::T_I32, 4);
     xfer += oprot->writeI32(this->ttl);
@@ -105,8 +103,8 @@ uint32_t Column::write(::apache::thrift::protocol::TProtocol* oprot) const {
   return xfer;
 }
 
-const char* SuperColumn::ascii_fingerprint = "33B3E5A6E294B6FCDB3F6EB567D3DB04";
-const uint8_t SuperColumn::binary_fingerprint[16] = {0x33,0xB3,0xE5,0xA6,0xE2,0x94,0xB6,0xFC,0xDB,0x3F,0x6E,0xB5,0x67,0xD3,0xDB,0x04};
+const char* SuperColumn::ascii_fingerprint = "470EFC558004E98D92D604898305C04E";
+const uint8_t SuperColumn::binary_fingerprint[16] = {0x47,0x0E,0xFC,0x55,0x80,0x04,0xE9,0x8D,0x92,0xD6,0x04,0x89,0x83,0x05,0xC0,0x4E};
 
 uint32_t SuperColumn::read(::apache::thrift::protocol::TProtocol* iprot) {
 
@@ -196,8 +194,170 @@ uint32_t SuperColumn::write(::apache::thrift::protocol::TProtocol* oprot) const 
   return xfer;
 }
 
-const char* ColumnOrSuperColumn::ascii_fingerprint = "C3B825B665DD0C548851BCD1D6D0D72E";
-const uint8_t ColumnOrSuperColumn::binary_fingerprint[16] = {0xC3,0xB8,0x25,0xB6,0x65,0xDD,0x0C,0x54,0x88,0x51,0xBC,0xD1,0xD6,0xD0,0xD7,0x2E};
+const char* CounterColumn::ascii_fingerprint = "1CCCF6FC31CFD1D61BBBB1BAF3590620";
+const uint8_t CounterColumn::binary_fingerprint[16] = {0x1C,0xCC,0xF6,0xFC,0x31,0xCF,0xD1,0xD6,0x1B,0xBB,0xB1,0xBA,0xF3,0x59,0x06,0x20};
+
+uint32_t CounterColumn::read(::apache::thrift::protocol::TProtocol* iprot) {
+
+  uint32_t xfer = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TType ftype;
+  int16_t fid;
+
+  xfer += iprot->readStructBegin(fname);
+
+  using ::apache::thrift::protocol::TProtocolException;
+
+  bool isset_name = false;
+  bool isset_value = false;
+
+  while (true)
+  {
+    xfer += iprot->readFieldBegin(fname, ftype, fid);
+    if (ftype == ::apache::thrift::protocol::T_STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+        if (ftype == ::apache::thrift::protocol::T_STRING) {
+          xfer += iprot->readBinary(this->name);
+          isset_name = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_I64) {
+          xfer += iprot->readI64(this->value);
+          isset_value = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      default:
+        xfer += iprot->skip(ftype);
+        break;
+    }
+    xfer += iprot->readFieldEnd();
+  }
+
+  xfer += iprot->readStructEnd();
+
+  if (!isset_name)
+    throw TProtocolException(TProtocolException::INVALID_DATA);
+  if (!isset_value)
+    throw TProtocolException(TProtocolException::INVALID_DATA);
+  return xfer;
+}
+
+uint32_t CounterColumn::write(::apache::thrift::protocol::TProtocol* oprot) const {
+  uint32_t xfer = 0;
+  xfer += oprot->writeStructBegin("CounterColumn");
+  xfer += oprot->writeFieldBegin("name", ::apache::thrift::protocol::T_STRING, 1);
+  xfer += oprot->writeBinary(this->name);
+  xfer += oprot->writeFieldEnd();
+  xfer += oprot->writeFieldBegin("value", ::apache::thrift::protocol::T_I64, 2);
+  xfer += oprot->writeI64(this->value);
+  xfer += oprot->writeFieldEnd();
+  xfer += oprot->writeFieldStop();
+  xfer += oprot->writeStructEnd();
+  return xfer;
+}
+
+const char* CounterSuperColumn::ascii_fingerprint = "CD4C8C4BF7753E46DE417CDE369343A4";
+const uint8_t CounterSuperColumn::binary_fingerprint[16] = {0xCD,0x4C,0x8C,0x4B,0xF7,0x75,0x3E,0x46,0xDE,0x41,0x7C,0xDE,0x36,0x93,0x43,0xA4};
+
+uint32_t CounterSuperColumn::read(::apache::thrift::protocol::TProtocol* iprot) {
+
+  uint32_t xfer = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TType ftype;
+  int16_t fid;
+
+  xfer += iprot->readStructBegin(fname);
+
+  using ::apache::thrift::protocol::TProtocolException;
+
+  bool isset_name = false;
+  bool isset_columns = false;
+
+  while (true)
+  {
+    xfer += iprot->readFieldBegin(fname, ftype, fid);
+    if (ftype == ::apache::thrift::protocol::T_STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+        if (ftype == ::apache::thrift::protocol::T_STRING) {
+          xfer += iprot->readBinary(this->name);
+          isset_name = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_LIST) {
+          {
+            this->columns.clear();
+            uint32_t _size6;
+            ::apache::thrift::protocol::TType _etype9;
+            iprot->readListBegin(_etype9, _size6);
+            this->columns.resize(_size6);
+            uint32_t _i10;
+            for (_i10 = 0; _i10 < _size6; ++_i10)
+            {
+              xfer += this->columns[_i10].read(iprot);
+            }
+            iprot->readListEnd();
+          }
+          isset_columns = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      default:
+        xfer += iprot->skip(ftype);
+        break;
+    }
+    xfer += iprot->readFieldEnd();
+  }
+
+  xfer += iprot->readStructEnd();
+
+  if (!isset_name)
+    throw TProtocolException(TProtocolException::INVALID_DATA);
+  if (!isset_columns)
+    throw TProtocolException(TProtocolException::INVALID_DATA);
+  return xfer;
+}
+
+uint32_t CounterSuperColumn::write(::apache::thrift::protocol::TProtocol* oprot) const {
+  uint32_t xfer = 0;
+  xfer += oprot->writeStructBegin("CounterSuperColumn");
+  xfer += oprot->writeFieldBegin("name", ::apache::thrift::protocol::T_STRING, 1);
+  xfer += oprot->writeBinary(this->name);
+  xfer += oprot->writeFieldEnd();
+  xfer += oprot->writeFieldBegin("columns", ::apache::thrift::protocol::T_LIST, 2);
+  {
+    xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, this->columns.size());
+    std::vector<CounterColumn> ::const_iterator _iter11;
+    for (_iter11 = this->columns.begin(); _iter11 != this->columns.end(); ++_iter11)
+    {
+      xfer += (*_iter11).write(oprot);
+    }
+    xfer += oprot->writeListEnd();
+  }
+  xfer += oprot->writeFieldEnd();
+  xfer += oprot->writeFieldStop();
+  xfer += oprot->writeStructEnd();
+  return xfer;
+}
+
+const char* ColumnOrSuperColumn::ascii_fingerprint = "2B34AC9E80F1DAA3A2A63B1AB1841E61";
+const uint8_t ColumnOrSuperColumn::binary_fingerprint[16] = {0x2B,0x34,0xAC,0x9E,0x80,0xF1,0xDA,0xA3,0xA2,0xA6,0x3B,0x1A,0xB1,0x84,0x1E,0x61};
 
 uint32_t ColumnOrSuperColumn::read(::apache::thrift::protocol::TProtocol* iprot) {
 
@@ -235,6 +395,22 @@ uint32_t ColumnOrSuperColumn::read(::apache::thrift::protocol::TProtocol* iprot)
           xfer += iprot->skip(ftype);
         }
         break;
+      case 3:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->counter_column.read(iprot);
+          this->__isset.counter_column = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 4:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->counter_super_column.read(iprot);
+          this->__isset.counter_super_column = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
       default:
         xfer += iprot->skip(ftype);
         break;
@@ -258,6 +434,16 @@ uint32_t ColumnOrSuperColumn::write(::apache::thrift::protocol::TProtocol* oprot
   if (this->__isset.super_column) {
     xfer += oprot->writeFieldBegin("super_column", ::apache::thrift::protocol::T_STRUCT, 2);
     xfer += this->super_column.write(oprot);
+    xfer += oprot->writeFieldEnd();
+  }
+  if (this->__isset.counter_column) {
+    xfer += oprot->writeFieldBegin("counter_column", ::apache::thrift::protocol::T_STRUCT, 3);
+    xfer += this->counter_column.write(oprot);
+    xfer += oprot->writeFieldEnd();
+  }
+  if (this->__isset.counter_super_column) {
+    xfer += oprot->writeFieldBegin("counter_super_column", ::apache::thrift::protocol::T_STRUCT, 4);
+    xfer += this->counter_super_column.write(oprot);
     xfer += oprot->writeFieldEnd();
   }
   xfer += oprot->writeFieldStop();
@@ -565,6 +751,49 @@ uint32_t AuthorizationException::write(::apache::thrift::protocol::TProtocol* op
   return xfer;
 }
 
+const char* SchemaDisagreementException::ascii_fingerprint = "99914B932BD37A50B983C5E7C90AE93B";
+const uint8_t SchemaDisagreementException::binary_fingerprint[16] = {0x99,0x91,0x4B,0x93,0x2B,0xD3,0x7A,0x50,0xB9,0x83,0xC5,0xE7,0xC9,0x0A,0xE9,0x3B};
+
+uint32_t SchemaDisagreementException::read(::apache::thrift::protocol::TProtocol* iprot) {
+
+  uint32_t xfer = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TType ftype;
+  int16_t fid;
+
+  xfer += iprot->readStructBegin(fname);
+
+  using ::apache::thrift::protocol::TProtocolException;
+
+
+  while (true)
+  {
+    xfer += iprot->readFieldBegin(fname, ftype, fid);
+    if (ftype == ::apache::thrift::protocol::T_STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      default:
+        xfer += iprot->skip(ftype);
+        break;
+    }
+    xfer += iprot->readFieldEnd();
+  }
+
+  xfer += iprot->readStructEnd();
+
+  return xfer;
+}
+
+uint32_t SchemaDisagreementException::write(::apache::thrift::protocol::TProtocol* oprot) const {
+  uint32_t xfer = 0;
+  xfer += oprot->writeStructBegin("SchemaDisagreementException");
+  xfer += oprot->writeFieldStop();
+  xfer += oprot->writeStructEnd();
+  return xfer;
+}
+
 const char* ColumnParent::ascii_fingerprint = "0A13AE61181713A4100DFFB3EC293822";
 const uint8_t ColumnParent::binary_fingerprint[16] = {0x0A,0x13,0xAE,0x61,0x18,0x17,0x13,0xA4,0x10,0x0D,0xFF,0xB3,0xEC,0x29,0x38,0x22};
 
@@ -844,14 +1073,14 @@ uint32_t SlicePredicate::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->column_names.clear();
-            uint32_t _size6;
-            ::apache::thrift::protocol::TType _etype9;
-            iprot->readListBegin(_etype9, _size6);
-            this->column_names.resize(_size6);
-            uint32_t _i10;
-            for (_i10 = 0; _i10 < _size6; ++_i10)
+            uint32_t _size12;
+            ::apache::thrift::protocol::TType _etype15;
+            iprot->readListBegin(_etype15, _size12);
+            this->column_names.resize(_size12);
+            uint32_t _i16;
+            for (_i16 = 0; _i16 < _size12; ++_i16)
             {
-              xfer += iprot->readBinary(this->column_names[_i10]);
+              xfer += iprot->readBinary(this->column_names[_i16]);
             }
             iprot->readListEnd();
           }
@@ -887,10 +1116,10 @@ uint32_t SlicePredicate::write(::apache::thrift::protocol::TProtocol* oprot) con
     xfer += oprot->writeFieldBegin("column_names", ::apache::thrift::protocol::T_LIST, 1);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, this->column_names.size());
-      std::vector<std::string> ::const_iterator _iter11;
-      for (_iter11 = this->column_names.begin(); _iter11 != this->column_names.end(); ++_iter11)
+      std::vector<std::string> ::const_iterator _iter17;
+      for (_iter17 = this->column_names.begin(); _iter17 != this->column_names.end(); ++_iter17)
       {
-        xfer += oprot->writeBinary((*_iter11));
+        xfer += oprot->writeBinary((*_iter17));
       }
       xfer += oprot->writeListEnd();
     }
@@ -942,9 +1171,9 @@ uint32_t IndexExpression::read(::apache::thrift::protocol::TProtocol* iprot) {
         break;
       case 2:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast12;
-          xfer += iprot->readI32(ecast12);
-          this->op = (IndexOperator::type)ecast12;
+          int32_t ecast18;
+          xfer += iprot->readI32(ecast18);
+          this->op = (IndexOperator::type)ecast18;
           isset_op = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -1023,14 +1252,14 @@ uint32_t IndexClause::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->expressions.clear();
-            uint32_t _size13;
-            ::apache::thrift::protocol::TType _etype16;
-            iprot->readListBegin(_etype16, _size13);
-            this->expressions.resize(_size13);
-            uint32_t _i17;
-            for (_i17 = 0; _i17 < _size13; ++_i17)
+            uint32_t _size19;
+            ::apache::thrift::protocol::TType _etype22;
+            iprot->readListBegin(_etype22, _size19);
+            this->expressions.resize(_size19);
+            uint32_t _i23;
+            for (_i23 = 0; _i23 < _size19; ++_i23)
             {
-              xfer += this->expressions[_i17].read(iprot);
+              xfer += this->expressions[_i23].read(iprot);
             }
             iprot->readListEnd();
           }
@@ -1079,10 +1308,10 @@ uint32_t IndexClause::write(::apache::thrift::protocol::TProtocol* oprot) const 
   xfer += oprot->writeFieldBegin("expressions", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, this->expressions.size());
-    std::vector<IndexExpression> ::const_iterator _iter18;
-    for (_iter18 = this->expressions.begin(); _iter18 != this->expressions.end(); ++_iter18)
+    std::vector<IndexExpression> ::const_iterator _iter24;
+    for (_iter24 = this->expressions.begin(); _iter24 != this->expressions.end(); ++_iter24)
     {
-      xfer += (*_iter18).write(oprot);
+      xfer += (*_iter24).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -1207,8 +1436,8 @@ uint32_t KeyRange::write(::apache::thrift::protocol::TProtocol* oprot) const {
   return xfer;
 }
 
-const char* KeySlice::ascii_fingerprint = "23AD778D2AF7838AF7670990033673A1";
-const uint8_t KeySlice::binary_fingerprint[16] = {0x23,0xAD,0x77,0x8D,0x2A,0xF7,0x83,0x8A,0xF7,0x67,0x09,0x90,0x03,0x36,0x73,0xA1};
+const char* KeySlice::ascii_fingerprint = "D1568675B0C135C909E3169B72A4DA3D";
+const uint8_t KeySlice::binary_fingerprint[16] = {0xD1,0x56,0x86,0x75,0xB0,0xC1,0x35,0xC9,0x09,0xE3,0x16,0x9B,0x72,0xA4,0xDA,0x3D};
 
 uint32_t KeySlice::read(::apache::thrift::protocol::TProtocol* iprot) {
 
@@ -1244,14 +1473,14 @@ uint32_t KeySlice::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->columns.clear();
-            uint32_t _size19;
-            ::apache::thrift::protocol::TType _etype22;
-            iprot->readListBegin(_etype22, _size19);
-            this->columns.resize(_size19);
-            uint32_t _i23;
-            for (_i23 = 0; _i23 < _size19; ++_i23)
+            uint32_t _size25;
+            ::apache::thrift::protocol::TType _etype28;
+            iprot->readListBegin(_etype28, _size25);
+            this->columns.resize(_size25);
+            uint32_t _i29;
+            for (_i29 = 0; _i29 < _size25; ++_i29)
             {
-              xfer += this->columns[_i23].read(iprot);
+              xfer += this->columns[_i29].read(iprot);
             }
             iprot->readListEnd();
           }
@@ -1285,10 +1514,10 @@ uint32_t KeySlice::write(::apache::thrift::protocol::TProtocol* oprot) const {
   xfer += oprot->writeFieldBegin("columns", ::apache::thrift::protocol::T_LIST, 2);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, this->columns.size());
-    std::vector<ColumnOrSuperColumn> ::const_iterator _iter24;
-    for (_iter24 = this->columns.begin(); _iter24 != this->columns.end(); ++_iter24)
+    std::vector<ColumnOrSuperColumn> ::const_iterator _iter30;
+    for (_iter30 = this->columns.begin(); _iter30 != this->columns.end(); ++_iter30)
     {
-      xfer += (*_iter24).write(oprot);
+      xfer += (*_iter30).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -1369,8 +1598,8 @@ uint32_t KeyCount::write(::apache::thrift::protocol::TProtocol* oprot) const {
   return xfer;
 }
 
-const char* Deletion::ascii_fingerprint = "1E4E5C4E0D45BE5064D14AFD23096B8B";
-const uint8_t Deletion::binary_fingerprint[16] = {0x1E,0x4E,0x5C,0x4E,0x0D,0x45,0xBE,0x50,0x64,0xD1,0x4A,0xFD,0x23,0x09,0x6B,0x8B};
+const char* Deletion::ascii_fingerprint = "40F33ECF1C932CA77C2414C4E6C60CBE";
+const uint8_t Deletion::binary_fingerprint[16] = {0x40,0xF3,0x3E,0xCF,0x1C,0x93,0x2C,0xA7,0x7C,0x24,0x14,0xC4,0xE6,0xC6,0x0C,0xBE};
 
 uint32_t Deletion::read(::apache::thrift::protocol::TProtocol* iprot) {
 
@@ -1383,7 +1612,6 @@ uint32_t Deletion::read(::apache::thrift::protocol::TProtocol* iprot) {
 
   using ::apache::thrift::protocol::TProtocolException;
 
-  bool isset_timestamp = false;
 
   while (true)
   {
@@ -1396,7 +1624,7 @@ uint32_t Deletion::read(::apache::thrift::protocol::TProtocol* iprot) {
       case 1:
         if (ftype == ::apache::thrift::protocol::T_I64) {
           xfer += iprot->readI64(this->timestamp);
-          isset_timestamp = true;
+          this->__isset.timestamp = true;
         } else {
           xfer += iprot->skip(ftype);
         }
@@ -1426,17 +1654,17 @@ uint32_t Deletion::read(::apache::thrift::protocol::TProtocol* iprot) {
 
   xfer += iprot->readStructEnd();
 
-  if (!isset_timestamp)
-    throw TProtocolException(TProtocolException::INVALID_DATA);
   return xfer;
 }
 
 uint32_t Deletion::write(::apache::thrift::protocol::TProtocol* oprot) const {
   uint32_t xfer = 0;
   xfer += oprot->writeStructBegin("Deletion");
-  xfer += oprot->writeFieldBegin("timestamp", ::apache::thrift::protocol::T_I64, 1);
-  xfer += oprot->writeI64(this->timestamp);
-  xfer += oprot->writeFieldEnd();
+  if (this->__isset.timestamp) {
+    xfer += oprot->writeFieldBegin("timestamp", ::apache::thrift::protocol::T_I64, 1);
+    xfer += oprot->writeI64(this->timestamp);
+    xfer += oprot->writeFieldEnd();
+  }
   if (this->__isset.super_column) {
     xfer += oprot->writeFieldBegin("super_column", ::apache::thrift::protocol::T_STRING, 2);
     xfer += oprot->writeBinary(this->super_column);
@@ -1452,8 +1680,8 @@ uint32_t Deletion::write(::apache::thrift::protocol::TProtocol* oprot) const {
   return xfer;
 }
 
-const char* Mutation::ascii_fingerprint = "BFF60385C4A40853485F8D8CC62A8C25";
-const uint8_t Mutation::binary_fingerprint[16] = {0xBF,0xF6,0x03,0x85,0xC4,0xA4,0x08,0x53,0x48,0x5F,0x8D,0x8C,0xC6,0x2A,0x8C,0x25};
+const char* Mutation::ascii_fingerprint = "E8B65DF3979C6868F80DF81F8E769E63";
+const uint8_t Mutation::binary_fingerprint[16] = {0xE8,0xB6,0x5D,0xF3,0x97,0x9C,0x68,0x68,0xF8,0x0D,0xF8,0x1F,0x8E,0x76,0x9E,0x63};
 
 uint32_t Mutation::read(::apache::thrift::protocol::TProtocol* iprot) {
 
@@ -1567,14 +1795,14 @@ uint32_t TokenRange::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->endpoints.clear();
-            uint32_t _size25;
-            ::apache::thrift::protocol::TType _etype28;
-            iprot->readListBegin(_etype28, _size25);
-            this->endpoints.resize(_size25);
-            uint32_t _i29;
-            for (_i29 = 0; _i29 < _size25; ++_i29)
+            uint32_t _size31;
+            ::apache::thrift::protocol::TType _etype34;
+            iprot->readListBegin(_etype34, _size31);
+            this->endpoints.resize(_size31);
+            uint32_t _i35;
+            for (_i35 = 0; _i35 < _size31; ++_i35)
             {
-              xfer += iprot->readString(this->endpoints[_i29]);
+              xfer += iprot->readString(this->endpoints[_i35]);
             }
             iprot->readListEnd();
           }
@@ -1613,10 +1841,10 @@ uint32_t TokenRange::write(::apache::thrift::protocol::TProtocol* oprot) const {
   xfer += oprot->writeFieldBegin("endpoints", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, this->endpoints.size());
-    std::vector<std::string> ::const_iterator _iter30;
-    for (_iter30 = this->endpoints.begin(); _iter30 != this->endpoints.end(); ++_iter30)
+    std::vector<std::string> ::const_iterator _iter36;
+    for (_iter36 = this->endpoints.begin(); _iter36 != this->endpoints.end(); ++_iter36)
     {
-      xfer += oprot->writeString((*_iter30));
+      xfer += oprot->writeString((*_iter36));
     }
     xfer += oprot->writeListEnd();
   }
@@ -1654,17 +1882,17 @@ uint32_t AuthenticationRequest::read(::apache::thrift::protocol::TProtocol* ipro
         if (ftype == ::apache::thrift::protocol::T_MAP) {
           {
             this->credentials.clear();
-            uint32_t _size31;
-            ::apache::thrift::protocol::TType _ktype32;
-            ::apache::thrift::protocol::TType _vtype33;
-            iprot->readMapBegin(_ktype32, _vtype33, _size31);
-            uint32_t _i35;
-            for (_i35 = 0; _i35 < _size31; ++_i35)
+            uint32_t _size37;
+            ::apache::thrift::protocol::TType _ktype38;
+            ::apache::thrift::protocol::TType _vtype39;
+            iprot->readMapBegin(_ktype38, _vtype39, _size37);
+            uint32_t _i41;
+            for (_i41 = 0; _i41 < _size37; ++_i41)
             {
-              std::string _key36;
-              xfer += iprot->readString(_key36);
-              std::string& _val37 = this->credentials[_key36];
-              xfer += iprot->readString(_val37);
+              std::string _key42;
+              xfer += iprot->readString(_key42);
+              std::string& _val43 = this->credentials[_key42];
+              xfer += iprot->readString(_val43);
             }
             iprot->readMapEnd();
           }
@@ -1693,11 +1921,11 @@ uint32_t AuthenticationRequest::write(::apache::thrift::protocol::TProtocol* opr
   xfer += oprot->writeFieldBegin("credentials", ::apache::thrift::protocol::T_MAP, 1);
   {
     xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_STRING, ::apache::thrift::protocol::T_STRING, this->credentials.size());
-    std::map<std::string, std::string> ::const_iterator _iter38;
-    for (_iter38 = this->credentials.begin(); _iter38 != this->credentials.end(); ++_iter38)
+    std::map<std::string, std::string> ::const_iterator _iter44;
+    for (_iter44 = this->credentials.begin(); _iter44 != this->credentials.end(); ++_iter44)
     {
-      xfer += oprot->writeString(_iter38->first);
-      xfer += oprot->writeString(_iter38->second);
+      xfer += oprot->writeString(_iter44->first);
+      xfer += oprot->writeString(_iter44->second);
     }
     xfer += oprot->writeMapEnd();
   }
@@ -1750,9 +1978,9 @@ uint32_t ColumnDef::read(::apache::thrift::protocol::TProtocol* iprot) {
         break;
       case 3:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast39;
-          xfer += iprot->readI32(ecast39);
-          this->index_type = (IndexType::type)ecast39;
+          int32_t ecast45;
+          xfer += iprot->readI32(ecast45);
+          this->index_type = (IndexType::type)ecast45;
           this->__isset.index_type = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -1806,8 +2034,8 @@ uint32_t ColumnDef::write(::apache::thrift::protocol::TProtocol* oprot) const {
   return xfer;
 }
 
-const char* CfDef::ascii_fingerprint = "2198376BDF233688F56E7E7A62BD2725";
-const uint8_t CfDef::binary_fingerprint[16] = {0x21,0x98,0x37,0x6B,0xDF,0x23,0x36,0x88,0xF5,0x6E,0x7E,0x7A,0x62,0xBD,0x27,0x25};
+const char* CfDef::ascii_fingerprint = "6E1C9EB571AF43C75C2F79C63FAEA424";
+const uint8_t CfDef::binary_fingerprint[16] = {0x6E,0x1C,0x9E,0xB5,0x71,0xAF,0x43,0xC7,0x5C,0x2F,0x79,0xC6,0x3F,0xAE,0xA4,0x24};
 
 uint32_t CfDef::read(::apache::thrift::protocol::TProtocol* iprot) {
 
@@ -1907,14 +2135,14 @@ uint32_t CfDef::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->column_metadata.clear();
-            uint32_t _size40;
-            ::apache::thrift::protocol::TType _etype43;
-            iprot->readListBegin(_etype43, _size40);
-            this->column_metadata.resize(_size40);
-            uint32_t _i44;
-            for (_i44 = 0; _i44 < _size40; ++_i44)
+            uint32_t _size46;
+            ::apache::thrift::protocol::TType _etype49;
+            iprot->readListBegin(_etype49, _size46);
+            this->column_metadata.resize(_size46);
+            uint32_t _i50;
+            for (_i50 = 0; _i50 < _size46; ++_i50)
             {
-              xfer += this->column_metadata[_i44].read(iprot);
+              xfer += this->column_metadata[_i50].read(iprot);
             }
             iprot->readListEnd();
           }
@@ -2003,6 +2231,46 @@ uint32_t CfDef::read(::apache::thrift::protocol::TProtocol* iprot) {
           xfer += iprot->skip(ftype);
         }
         break;
+      case 24:
+        if (ftype == ::apache::thrift::protocol::T_BOOL) {
+          xfer += iprot->readBool(this->replicate_on_write);
+          this->__isset.replicate_on_write = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 25:
+        if (ftype == ::apache::thrift::protocol::T_DOUBLE) {
+          xfer += iprot->readDouble(this->merge_shards_chance);
+          this->__isset.merge_shards_chance = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 26:
+        if (ftype == ::apache::thrift::protocol::T_STRING) {
+          xfer += iprot->readString(this->key_validation_class);
+          this->__isset.key_validation_class = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 27:
+        if (ftype == ::apache::thrift::protocol::T_STRING) {
+          xfer += iprot->readString(this->row_cache_provider);
+          this->__isset.row_cache_provider = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 28:
+        if (ftype == ::apache::thrift::protocol::T_STRING) {
+          xfer += iprot->readBinary(this->key_alias);
+          this->__isset.key_alias = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
       default:
         xfer += iprot->skip(ftype);
         break;
@@ -2067,10 +2335,10 @@ uint32_t CfDef::write(::apache::thrift::protocol::TProtocol* oprot) const {
     xfer += oprot->writeFieldBegin("column_metadata", ::apache::thrift::protocol::T_LIST, 13);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, this->column_metadata.size());
-      std::vector<ColumnDef> ::const_iterator _iter45;
-      for (_iter45 = this->column_metadata.begin(); _iter45 != this->column_metadata.end(); ++_iter45)
+      std::vector<ColumnDef> ::const_iterator _iter51;
+      for (_iter51 = this->column_metadata.begin(); _iter51 != this->column_metadata.end(); ++_iter51)
       {
-        xfer += (*_iter45).write(oprot);
+        xfer += (*_iter51).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -2126,13 +2394,38 @@ uint32_t CfDef::write(::apache::thrift::protocol::TProtocol* oprot) const {
     xfer += oprot->writeDouble(this->memtable_operations_in_millions);
     xfer += oprot->writeFieldEnd();
   }
+  if (this->__isset.replicate_on_write) {
+    xfer += oprot->writeFieldBegin("replicate_on_write", ::apache::thrift::protocol::T_BOOL, 24);
+    xfer += oprot->writeBool(this->replicate_on_write);
+    xfer += oprot->writeFieldEnd();
+  }
+  if (this->__isset.merge_shards_chance) {
+    xfer += oprot->writeFieldBegin("merge_shards_chance", ::apache::thrift::protocol::T_DOUBLE, 25);
+    xfer += oprot->writeDouble(this->merge_shards_chance);
+    xfer += oprot->writeFieldEnd();
+  }
+  if (this->__isset.key_validation_class) {
+    xfer += oprot->writeFieldBegin("key_validation_class", ::apache::thrift::protocol::T_STRING, 26);
+    xfer += oprot->writeString(this->key_validation_class);
+    xfer += oprot->writeFieldEnd();
+  }
+  if (this->__isset.row_cache_provider) {
+    xfer += oprot->writeFieldBegin("row_cache_provider", ::apache::thrift::protocol::T_STRING, 27);
+    xfer += oprot->writeString(this->row_cache_provider);
+    xfer += oprot->writeFieldEnd();
+  }
+  if (this->__isset.key_alias) {
+    xfer += oprot->writeFieldBegin("key_alias", ::apache::thrift::protocol::T_STRING, 28);
+    xfer += oprot->writeBinary(this->key_alias);
+    xfer += oprot->writeFieldEnd();
+  }
   xfer += oprot->writeFieldStop();
   xfer += oprot->writeStructEnd();
   return xfer;
 }
 
-const char* KsDef::ascii_fingerprint = "75BE67EF161D3DF7F283FF5C63C5F31A";
-const uint8_t KsDef::binary_fingerprint[16] = {0x75,0xBE,0x67,0xEF,0x16,0x1D,0x3D,0xF7,0xF2,0x83,0xFF,0x5C,0x63,0xC5,0xF3,0x1A};
+const char* KsDef::ascii_fingerprint = "820D5633D9CAAF0DA19926563FE0B07F";
+const uint8_t KsDef::binary_fingerprint[16] = {0x82,0x0D,0x56,0x33,0xD9,0xCA,0xAF,0x0D,0xA1,0x99,0x26,0x56,0x3F,0xE0,0xB0,0x7F};
 
 uint32_t KsDef::read(::apache::thrift::protocol::TProtocol* iprot) {
 
@@ -2147,7 +2440,6 @@ uint32_t KsDef::read(::apache::thrift::protocol::TProtocol* iprot) {
 
   bool isset_name = false;
   bool isset_strategy_class = false;
-  bool isset_replication_factor = false;
   bool isset_cf_defs = false;
 
   while (true)
@@ -2178,17 +2470,17 @@ uint32_t KsDef::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_MAP) {
           {
             this->strategy_options.clear();
-            uint32_t _size46;
-            ::apache::thrift::protocol::TType _ktype47;
-            ::apache::thrift::protocol::TType _vtype48;
-            iprot->readMapBegin(_ktype47, _vtype48, _size46);
-            uint32_t _i50;
-            for (_i50 = 0; _i50 < _size46; ++_i50)
+            uint32_t _size52;
+            ::apache::thrift::protocol::TType _ktype53;
+            ::apache::thrift::protocol::TType _vtype54;
+            iprot->readMapBegin(_ktype53, _vtype54, _size52);
+            uint32_t _i56;
+            for (_i56 = 0; _i56 < _size52; ++_i56)
             {
-              std::string _key51;
-              xfer += iprot->readString(_key51);
-              std::string& _val52 = this->strategy_options[_key51];
-              xfer += iprot->readString(_val52);
+              std::string _key57;
+              xfer += iprot->readString(_key57);
+              std::string& _val58 = this->strategy_options[_key57];
+              xfer += iprot->readString(_val58);
             }
             iprot->readMapEnd();
           }
@@ -2200,7 +2492,7 @@ uint32_t KsDef::read(::apache::thrift::protocol::TProtocol* iprot) {
       case 4:
         if (ftype == ::apache::thrift::protocol::T_I32) {
           xfer += iprot->readI32(this->replication_factor);
-          isset_replication_factor = true;
+          this->__isset.replication_factor = true;
         } else {
           xfer += iprot->skip(ftype);
         }
@@ -2209,18 +2501,26 @@ uint32_t KsDef::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->cf_defs.clear();
-            uint32_t _size53;
-            ::apache::thrift::protocol::TType _etype56;
-            iprot->readListBegin(_etype56, _size53);
-            this->cf_defs.resize(_size53);
-            uint32_t _i57;
-            for (_i57 = 0; _i57 < _size53; ++_i57)
+            uint32_t _size59;
+            ::apache::thrift::protocol::TType _etype62;
+            iprot->readListBegin(_etype62, _size59);
+            this->cf_defs.resize(_size59);
+            uint32_t _i63;
+            for (_i63 = 0; _i63 < _size59; ++_i63)
             {
-              xfer += this->cf_defs[_i57].read(iprot);
+              xfer += this->cf_defs[_i63].read(iprot);
             }
             iprot->readListEnd();
           }
           isset_cf_defs = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 6:
+        if (ftype == ::apache::thrift::protocol::T_BOOL) {
+          xfer += iprot->readBool(this->durable_writes);
+          this->__isset.durable_writes = true;
         } else {
           xfer += iprot->skip(ftype);
         }
@@ -2237,8 +2537,6 @@ uint32_t KsDef::read(::apache::thrift::protocol::TProtocol* iprot) {
   if (!isset_name)
     throw TProtocolException(TProtocolException::INVALID_DATA);
   if (!isset_strategy_class)
-    throw TProtocolException(TProtocolException::INVALID_DATA);
-  if (!isset_replication_factor)
     throw TProtocolException(TProtocolException::INVALID_DATA);
   if (!isset_cf_defs)
     throw TProtocolException(TProtocolException::INVALID_DATA);
@@ -2258,30 +2556,233 @@ uint32_t KsDef::write(::apache::thrift::protocol::TProtocol* oprot) const {
     xfer += oprot->writeFieldBegin("strategy_options", ::apache::thrift::protocol::T_MAP, 3);
     {
       xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_STRING, ::apache::thrift::protocol::T_STRING, this->strategy_options.size());
-      std::map<std::string, std::string> ::const_iterator _iter58;
-      for (_iter58 = this->strategy_options.begin(); _iter58 != this->strategy_options.end(); ++_iter58)
+      std::map<std::string, std::string> ::const_iterator _iter64;
+      for (_iter64 = this->strategy_options.begin(); _iter64 != this->strategy_options.end(); ++_iter64)
       {
-        xfer += oprot->writeString(_iter58->first);
-        xfer += oprot->writeString(_iter58->second);
+        xfer += oprot->writeString(_iter64->first);
+        xfer += oprot->writeString(_iter64->second);
       }
       xfer += oprot->writeMapEnd();
     }
     xfer += oprot->writeFieldEnd();
   }
-  xfer += oprot->writeFieldBegin("replication_factor", ::apache::thrift::protocol::T_I32, 4);
-  xfer += oprot->writeI32(this->replication_factor);
-  xfer += oprot->writeFieldEnd();
+  if (this->__isset.replication_factor) {
+    xfer += oprot->writeFieldBegin("replication_factor", ::apache::thrift::protocol::T_I32, 4);
+    xfer += oprot->writeI32(this->replication_factor);
+    xfer += oprot->writeFieldEnd();
+  }
   xfer += oprot->writeFieldBegin("cf_defs", ::apache::thrift::protocol::T_LIST, 5);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, this->cf_defs.size());
-    std::vector<CfDef> ::const_iterator _iter59;
-    for (_iter59 = this->cf_defs.begin(); _iter59 != this->cf_defs.end(); ++_iter59)
+    std::vector<CfDef> ::const_iterator _iter65;
+    for (_iter65 = this->cf_defs.begin(); _iter65 != this->cf_defs.end(); ++_iter65)
     {
-      xfer += (*_iter59).write(oprot);
+      xfer += (*_iter65).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
   xfer += oprot->writeFieldEnd();
+  if (this->__isset.durable_writes) {
+    xfer += oprot->writeFieldBegin("durable_writes", ::apache::thrift::protocol::T_BOOL, 6);
+    xfer += oprot->writeBool(this->durable_writes);
+    xfer += oprot->writeFieldEnd();
+  }
+  xfer += oprot->writeFieldStop();
+  xfer += oprot->writeStructEnd();
+  return xfer;
+}
+
+const char* CqlRow::ascii_fingerprint = "470EFC558004E98D92D604898305C04E";
+const uint8_t CqlRow::binary_fingerprint[16] = {0x47,0x0E,0xFC,0x55,0x80,0x04,0xE9,0x8D,0x92,0xD6,0x04,0x89,0x83,0x05,0xC0,0x4E};
+
+uint32_t CqlRow::read(::apache::thrift::protocol::TProtocol* iprot) {
+
+  uint32_t xfer = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TType ftype;
+  int16_t fid;
+
+  xfer += iprot->readStructBegin(fname);
+
+  using ::apache::thrift::protocol::TProtocolException;
+
+  bool isset_key = false;
+  bool isset_columns = false;
+
+  while (true)
+  {
+    xfer += iprot->readFieldBegin(fname, ftype, fid);
+    if (ftype == ::apache::thrift::protocol::T_STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+        if (ftype == ::apache::thrift::protocol::T_STRING) {
+          xfer += iprot->readBinary(this->key);
+          isset_key = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_LIST) {
+          {
+            this->columns.clear();
+            uint32_t _size66;
+            ::apache::thrift::protocol::TType _etype69;
+            iprot->readListBegin(_etype69, _size66);
+            this->columns.resize(_size66);
+            uint32_t _i70;
+            for (_i70 = 0; _i70 < _size66; ++_i70)
+            {
+              xfer += this->columns[_i70].read(iprot);
+            }
+            iprot->readListEnd();
+          }
+          isset_columns = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      default:
+        xfer += iprot->skip(ftype);
+        break;
+    }
+    xfer += iprot->readFieldEnd();
+  }
+
+  xfer += iprot->readStructEnd();
+
+  if (!isset_key)
+    throw TProtocolException(TProtocolException::INVALID_DATA);
+  if (!isset_columns)
+    throw TProtocolException(TProtocolException::INVALID_DATA);
+  return xfer;
+}
+
+uint32_t CqlRow::write(::apache::thrift::protocol::TProtocol* oprot) const {
+  uint32_t xfer = 0;
+  xfer += oprot->writeStructBegin("CqlRow");
+  xfer += oprot->writeFieldBegin("key", ::apache::thrift::protocol::T_STRING, 1);
+  xfer += oprot->writeBinary(this->key);
+  xfer += oprot->writeFieldEnd();
+  xfer += oprot->writeFieldBegin("columns", ::apache::thrift::protocol::T_LIST, 2);
+  {
+    xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, this->columns.size());
+    std::vector<Column> ::const_iterator _iter71;
+    for (_iter71 = this->columns.begin(); _iter71 != this->columns.end(); ++_iter71)
+    {
+      xfer += (*_iter71).write(oprot);
+    }
+    xfer += oprot->writeListEnd();
+  }
+  xfer += oprot->writeFieldEnd();
+  xfer += oprot->writeFieldStop();
+  xfer += oprot->writeStructEnd();
+  return xfer;
+}
+
+const char* CqlResult::ascii_fingerprint = "08BC83A60D342CCE8C03B7AB57B7570E";
+const uint8_t CqlResult::binary_fingerprint[16] = {0x08,0xBC,0x83,0xA6,0x0D,0x34,0x2C,0xCE,0x8C,0x03,0xB7,0xAB,0x57,0xB7,0x57,0x0E};
+
+uint32_t CqlResult::read(::apache::thrift::protocol::TProtocol* iprot) {
+
+  uint32_t xfer = 0;
+  std::string fname;
+  ::apache::thrift::protocol::TType ftype;
+  int16_t fid;
+
+  xfer += iprot->readStructBegin(fname);
+
+  using ::apache::thrift::protocol::TProtocolException;
+
+  bool isset_type = false;
+
+  while (true)
+  {
+    xfer += iprot->readFieldBegin(fname, ftype, fid);
+    if (ftype == ::apache::thrift::protocol::T_STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+        if (ftype == ::apache::thrift::protocol::T_I32) {
+          int32_t ecast72;
+          xfer += iprot->readI32(ecast72);
+          this->type = (CqlResultType::type)ecast72;
+          isset_type = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_LIST) {
+          {
+            this->rows.clear();
+            uint32_t _size73;
+            ::apache::thrift::protocol::TType _etype76;
+            iprot->readListBegin(_etype76, _size73);
+            this->rows.resize(_size73);
+            uint32_t _i77;
+            for (_i77 = 0; _i77 < _size73; ++_i77)
+            {
+              xfer += this->rows[_i77].read(iprot);
+            }
+            iprot->readListEnd();
+          }
+          this->__isset.rows = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 3:
+        if (ftype == ::apache::thrift::protocol::T_I32) {
+          xfer += iprot->readI32(this->num);
+          this->__isset.num = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      default:
+        xfer += iprot->skip(ftype);
+        break;
+    }
+    xfer += iprot->readFieldEnd();
+  }
+
+  xfer += iprot->readStructEnd();
+
+  if (!isset_type)
+    throw TProtocolException(TProtocolException::INVALID_DATA);
+  return xfer;
+}
+
+uint32_t CqlResult::write(::apache::thrift::protocol::TProtocol* oprot) const {
+  uint32_t xfer = 0;
+  xfer += oprot->writeStructBegin("CqlResult");
+  xfer += oprot->writeFieldBegin("type", ::apache::thrift::protocol::T_I32, 1);
+  xfer += oprot->writeI32((int32_t)this->type);
+  xfer += oprot->writeFieldEnd();
+  if (this->__isset.rows) {
+    xfer += oprot->writeFieldBegin("rows", ::apache::thrift::protocol::T_LIST, 2);
+    {
+      xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, this->rows.size());
+      std::vector<CqlRow> ::const_iterator _iter78;
+      for (_iter78 = this->rows.begin(); _iter78 != this->rows.end(); ++_iter78)
+      {
+        xfer += (*_iter78).write(oprot);
+      }
+      xfer += oprot->writeListEnd();
+    }
+    xfer += oprot->writeFieldEnd();
+  }
+  if (this->__isset.num) {
+    xfer += oprot->writeFieldBegin("num", ::apache::thrift::protocol::T_I32, 3);
+    xfer += oprot->writeI32(this->num);
+    xfer += oprot->writeFieldEnd();
+  }
   xfer += oprot->writeFieldStop();
   xfer += oprot->writeStructEnd();
   return xfer;

--- a/libgenthrift/cassandra_types.h
+++ b/libgenthrift/cassandra_types.h
@@ -22,7 +22,9 @@ struct ConsistencyLevel {
     LOCAL_QUORUM = 3,
     EACH_QUORUM = 4,
     ALL = 5,
-    ANY = 6
+    ANY = 6,
+    TWO = 7,
+    THREE = 8
   };
 };
 
@@ -42,16 +44,33 @@ struct IndexType {
   };
 };
 
+struct Compression {
+  enum type {
+    GZIP = 1,
+    NONE = 2
+  };
+};
+
+struct CqlResultType {
+  enum type {
+    ROWS = 1,
+    VOID = 2,
+    INT = 3
+  };
+};
+
 typedef struct _Column__isset {
-  _Column__isset() : ttl(false) {}
+  _Column__isset() : value(false), timestamp(false), ttl(false) {}
+  bool value;
+  bool timestamp;
   bool ttl;
 } _Column__isset;
 
 class Column {
  public:
 
-  static const char* ascii_fingerprint; // = "AFF5A2690BB9979816507B2F6BD21062";
-  static const uint8_t binary_fingerprint[16]; // = {0xAF,0xF5,0xA2,0x69,0x0B,0xB9,0x97,0x98,0x16,0x50,0x7B,0x2F,0x6B,0xD2,0x10,0x62};
+  static const char* ascii_fingerprint; // = "3EE0E1C5C844001B62F08125068292CC";
+  static const uint8_t binary_fingerprint[16]; // = {0x3E,0xE0,0xE1,0xC5,0xC8,0x44,0x00,0x1B,0x62,0xF0,0x81,0x25,0x06,0x82,0x92,0xCC};
 
   Column() : name(""), value(""), timestamp(0), ttl(0) {
   }
@@ -69,9 +88,13 @@ class Column {
   {
     if (!(name == rhs.name))
       return false;
-    if (!(value == rhs.value))
+    if (__isset.value != rhs.__isset.value)
       return false;
-    if (!(timestamp == rhs.timestamp))
+    else if (__isset.value && !(value == rhs.value))
+      return false;
+    if (__isset.timestamp != rhs.__isset.timestamp)
+      return false;
+    else if (__isset.timestamp && !(timestamp == rhs.timestamp))
       return false;
     if (__isset.ttl != rhs.__isset.ttl)
       return false;
@@ -94,8 +117,8 @@ class Column {
 class SuperColumn {
  public:
 
-  static const char* ascii_fingerprint; // = "33B3E5A6E294B6FCDB3F6EB567D3DB04";
-  static const uint8_t binary_fingerprint[16]; // = {0x33,0xB3,0xE5,0xA6,0xE2,0x94,0xB6,0xFC,0xDB,0x3F,0x6E,0xB5,0x67,0xD3,0xDB,0x04};
+  static const char* ascii_fingerprint; // = "470EFC558004E98D92D604898305C04E";
+  static const uint8_t binary_fingerprint[16]; // = {0x47,0x0E,0xFC,0x55,0x80,0x04,0xE9,0x8D,0x92,0xD6,0x04,0x89,0x83,0x05,0xC0,0x4E};
 
   SuperColumn() : name("") {
   }
@@ -124,17 +147,87 @@ class SuperColumn {
 
 };
 
+
+class CounterColumn {
+ public:
+
+  static const char* ascii_fingerprint; // = "1CCCF6FC31CFD1D61BBBB1BAF3590620";
+  static const uint8_t binary_fingerprint[16]; // = {0x1C,0xCC,0xF6,0xFC,0x31,0xCF,0xD1,0xD6,0x1B,0xBB,0xB1,0xBA,0xF3,0x59,0x06,0x20};
+
+  CounterColumn() : name(""), value(0) {
+  }
+
+  virtual ~CounterColumn() throw() {}
+
+  std::string name;
+  int64_t value;
+
+  bool operator == (const CounterColumn & rhs) const
+  {
+    if (!(name == rhs.name))
+      return false;
+    if (!(value == rhs.value))
+      return false;
+    return true;
+  }
+  bool operator != (const CounterColumn &rhs) const {
+    return !(*this == rhs);
+  }
+
+  bool operator < (const CounterColumn & ) const;
+
+  uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
+  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
+
+};
+
+
+class CounterSuperColumn {
+ public:
+
+  static const char* ascii_fingerprint; // = "CD4C8C4BF7753E46DE417CDE369343A4";
+  static const uint8_t binary_fingerprint[16]; // = {0xCD,0x4C,0x8C,0x4B,0xF7,0x75,0x3E,0x46,0xDE,0x41,0x7C,0xDE,0x36,0x93,0x43,0xA4};
+
+  CounterSuperColumn() : name("") {
+  }
+
+  virtual ~CounterSuperColumn() throw() {}
+
+  std::string name;
+  std::vector<CounterColumn>  columns;
+
+  bool operator == (const CounterSuperColumn & rhs) const
+  {
+    if (!(name == rhs.name))
+      return false;
+    if (!(columns == rhs.columns))
+      return false;
+    return true;
+  }
+  bool operator != (const CounterSuperColumn &rhs) const {
+    return !(*this == rhs);
+  }
+
+  bool operator < (const CounterSuperColumn & ) const;
+
+  uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
+  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
+
+};
+
 typedef struct _ColumnOrSuperColumn__isset {
-  _ColumnOrSuperColumn__isset() : column(false), super_column(false) {}
+  _ColumnOrSuperColumn__isset() : column(false), super_column(false), counter_column(false), counter_super_column(false) {}
   bool column;
   bool super_column;
+  bool counter_column;
+  bool counter_super_column;
 } _ColumnOrSuperColumn__isset;
 
 class ColumnOrSuperColumn {
  public:
 
-  static const char* ascii_fingerprint; // = "C3B825B665DD0C548851BCD1D6D0D72E";
-  static const uint8_t binary_fingerprint[16]; // = {0xC3,0xB8,0x25,0xB6,0x65,0xDD,0x0C,0x54,0x88,0x51,0xBC,0xD1,0xD6,0xD0,0xD7,0x2E};
+  static const char* ascii_fingerprint; // = "2B34AC9E80F1DAA3A2A63B1AB1841E61";
+  static const uint8_t binary_fingerprint[16]; // = {0x2B,0x34,0xAC,0x9E,0x80,0xF1,0xDA,0xA3,0xA2,0xA6,0x3B,0x1A,0xB1,0x84,0x1E,0x61};
 
   ColumnOrSuperColumn() {
   }
@@ -143,6 +236,8 @@ class ColumnOrSuperColumn {
 
   Column column;
   SuperColumn super_column;
+  CounterColumn counter_column;
+  CounterSuperColumn counter_super_column;
 
   _ColumnOrSuperColumn__isset __isset;
 
@@ -155,6 +250,14 @@ class ColumnOrSuperColumn {
     if (__isset.super_column != rhs.__isset.super_column)
       return false;
     else if (__isset.super_column && !(super_column == rhs.super_column))
+      return false;
+    if (__isset.counter_column != rhs.__isset.counter_column)
+      return false;
+    else if (__isset.counter_column && !(counter_column == rhs.counter_column))
+      return false;
+    if (__isset.counter_super_column != rhs.__isset.counter_super_column)
+      return false;
+    else if (__isset.counter_super_column && !(counter_super_column == rhs.counter_super_column))
       return false;
     return true;
   }
@@ -340,6 +443,34 @@ class AuthorizationException : public ::apache::thrift::TException {
   }
 
   bool operator < (const AuthorizationException & ) const;
+
+  uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
+  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
+
+};
+
+
+class SchemaDisagreementException : public ::apache::thrift::TException {
+ public:
+
+  static const char* ascii_fingerprint; // = "99914B932BD37A50B983C5E7C90AE93B";
+  static const uint8_t binary_fingerprint[16]; // = {0x99,0x91,0x4B,0x93,0x2B,0xD3,0x7A,0x50,0xB9,0x83,0xC5,0xE7,0xC9,0x0A,0xE9,0x3B};
+
+  SchemaDisagreementException() {
+  }
+
+  virtual ~SchemaDisagreementException() throw() {}
+
+
+  bool operator == (const SchemaDisagreementException & /* rhs */) const
+  {
+    return true;
+  }
+  bool operator != (const SchemaDisagreementException &rhs) const {
+    return !(*this == rhs);
+  }
+
+  bool operator < (const SchemaDisagreementException & ) const;
 
   uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
   uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
@@ -659,8 +790,8 @@ class KeyRange {
 class KeySlice {
  public:
 
-  static const char* ascii_fingerprint; // = "23AD778D2AF7838AF7670990033673A1";
-  static const uint8_t binary_fingerprint[16]; // = {0x23,0xAD,0x77,0x8D,0x2A,0xF7,0x83,0x8A,0xF7,0x67,0x09,0x90,0x03,0x36,0x73,0xA1};
+  static const char* ascii_fingerprint; // = "D1568675B0C135C909E3169B72A4DA3D";
+  static const uint8_t binary_fingerprint[16]; // = {0xD1,0x56,0x86,0x75,0xB0,0xC1,0x35,0xC9,0x09,0xE3,0x16,0x9B,0x72,0xA4,0xDA,0x3D};
 
   KeySlice() : key("") {
   }
@@ -724,7 +855,8 @@ class KeyCount {
 };
 
 typedef struct _Deletion__isset {
-  _Deletion__isset() : super_column(false), predicate(false) {}
+  _Deletion__isset() : timestamp(false), super_column(false), predicate(false) {}
+  bool timestamp;
   bool super_column;
   bool predicate;
 } _Deletion__isset;
@@ -732,8 +864,8 @@ typedef struct _Deletion__isset {
 class Deletion {
  public:
 
-  static const char* ascii_fingerprint; // = "1E4E5C4E0D45BE5064D14AFD23096B8B";
-  static const uint8_t binary_fingerprint[16]; // = {0x1E,0x4E,0x5C,0x4E,0x0D,0x45,0xBE,0x50,0x64,0xD1,0x4A,0xFD,0x23,0x09,0x6B,0x8B};
+  static const char* ascii_fingerprint; // = "40F33ECF1C932CA77C2414C4E6C60CBE";
+  static const uint8_t binary_fingerprint[16]; // = {0x40,0xF3,0x3E,0xCF,0x1C,0x93,0x2C,0xA7,0x7C,0x24,0x14,0xC4,0xE6,0xC6,0x0C,0xBE};
 
   Deletion() : timestamp(0), super_column("") {
   }
@@ -748,7 +880,9 @@ class Deletion {
 
   bool operator == (const Deletion & rhs) const
   {
-    if (!(timestamp == rhs.timestamp))
+    if (__isset.timestamp != rhs.__isset.timestamp)
+      return false;
+    else if (__isset.timestamp && !(timestamp == rhs.timestamp))
       return false;
     if (__isset.super_column != rhs.__isset.super_column)
       return false;
@@ -780,8 +914,8 @@ typedef struct _Mutation__isset {
 class Mutation {
  public:
 
-  static const char* ascii_fingerprint; // = "BFF60385C4A40853485F8D8CC62A8C25";
-  static const uint8_t binary_fingerprint[16]; // = {0xBF,0xF6,0x03,0x85,0xC4,0xA4,0x08,0x53,0x48,0x5F,0x8D,0x8C,0xC6,0x2A,0x8C,0x25};
+  static const char* ascii_fingerprint; // = "E8B65DF3979C6868F80DF81F8E769E63";
+  static const uint8_t binary_fingerprint[16]; // = {0xE8,0xB6,0x5D,0xF3,0x97,0x9C,0x68,0x68,0xF8,0x0D,0xF8,0x1F,0x8E,0x76,0x9E,0x63};
 
   Mutation() {
   }
@@ -936,7 +1070,7 @@ class ColumnDef {
 };
 
 typedef struct _CfDef__isset {
-  _CfDef__isset() : column_type(false), comparator_type(false), subcomparator_type(false), comment(false), row_cache_size(false), key_cache_size(false), read_repair_chance(false), column_metadata(false), gc_grace_seconds(false), default_validation_class(false), id(false), min_compaction_threshold(false), max_compaction_threshold(false), row_cache_save_period_in_seconds(false), key_cache_save_period_in_seconds(false), memtable_flush_after_mins(false), memtable_throughput_in_mb(false), memtable_operations_in_millions(false) {}
+  _CfDef__isset() : column_type(false), comparator_type(false), subcomparator_type(false), comment(false), row_cache_size(false), key_cache_size(false), read_repair_chance(false), column_metadata(false), gc_grace_seconds(false), default_validation_class(false), id(false), min_compaction_threshold(false), max_compaction_threshold(false), row_cache_save_period_in_seconds(false), key_cache_save_period_in_seconds(false), memtable_flush_after_mins(false), memtable_throughput_in_mb(false), memtable_operations_in_millions(false), replicate_on_write(false), merge_shards_chance(false), key_validation_class(false), row_cache_provider(false), key_alias(false) {}
   bool column_type;
   bool comparator_type;
   bool subcomparator_type;
@@ -955,15 +1089,20 @@ typedef struct _CfDef__isset {
   bool memtable_flush_after_mins;
   bool memtable_throughput_in_mb;
   bool memtable_operations_in_millions;
+  bool replicate_on_write;
+  bool merge_shards_chance;
+  bool key_validation_class;
+  bool row_cache_provider;
+  bool key_alias;
 } _CfDef__isset;
 
 class CfDef {
  public:
 
-  static const char* ascii_fingerprint; // = "2198376BDF233688F56E7E7A62BD2725";
-  static const uint8_t binary_fingerprint[16]; // = {0x21,0x98,0x37,0x6B,0xDF,0x23,0x36,0x88,0xF5,0x6E,0x7E,0x7A,0x62,0xBD,0x27,0x25};
+  static const char* ascii_fingerprint; // = "6E1C9EB571AF43C75C2F79C63FAEA424";
+  static const uint8_t binary_fingerprint[16]; // = {0x6E,0x1C,0x9E,0xB5,0x71,0xAF,0x43,0xC7,0x5C,0x2F,0x79,0xC6,0x3F,0xAE,0xA4,0x24};
 
-  CfDef() : keyspace(""), name(""), column_type("Standard"), comparator_type("BytesType"), subcomparator_type(""), comment(""), row_cache_size(0), key_cache_size(200000), read_repair_chance(1), gc_grace_seconds(0), default_validation_class(""), id(0), min_compaction_threshold(0), max_compaction_threshold(0), row_cache_save_period_in_seconds(0), key_cache_save_period_in_seconds(0), memtable_flush_after_mins(0), memtable_throughput_in_mb(0), memtable_operations_in_millions(0) {
+  CfDef() : keyspace(""), name(""), column_type("Standard"), comparator_type("BytesType"), subcomparator_type(""), comment(""), row_cache_size(0), key_cache_size(200000), read_repair_chance(1), gc_grace_seconds(0), default_validation_class(""), id(0), min_compaction_threshold(0), max_compaction_threshold(0), row_cache_save_period_in_seconds(0), key_cache_save_period_in_seconds(0), memtable_flush_after_mins(0), memtable_throughput_in_mb(0), memtable_operations_in_millions(0), replicate_on_write(0), merge_shards_chance(0), key_validation_class(""), row_cache_provider("org.apache.cassandra.cache.ConcurrentLinkedHashCacheProvider"), key_alias("") {
   }
 
   virtual ~CfDef() throw() {}
@@ -988,6 +1127,11 @@ class CfDef {
   int32_t memtable_flush_after_mins;
   int32_t memtable_throughput_in_mb;
   double memtable_operations_in_millions;
+  bool replicate_on_write;
+  double merge_shards_chance;
+  std::string key_validation_class;
+  std::string row_cache_provider;
+  std::string key_alias;
 
   _CfDef__isset __isset;
 
@@ -1069,6 +1213,26 @@ class CfDef {
       return false;
     else if (__isset.memtable_operations_in_millions && !(memtable_operations_in_millions == rhs.memtable_operations_in_millions))
       return false;
+    if (__isset.replicate_on_write != rhs.__isset.replicate_on_write)
+      return false;
+    else if (__isset.replicate_on_write && !(replicate_on_write == rhs.replicate_on_write))
+      return false;
+    if (__isset.merge_shards_chance != rhs.__isset.merge_shards_chance)
+      return false;
+    else if (__isset.merge_shards_chance && !(merge_shards_chance == rhs.merge_shards_chance))
+      return false;
+    if (__isset.key_validation_class != rhs.__isset.key_validation_class)
+      return false;
+    else if (__isset.key_validation_class && !(key_validation_class == rhs.key_validation_class))
+      return false;
+    if (__isset.row_cache_provider != rhs.__isset.row_cache_provider)
+      return false;
+    else if (__isset.row_cache_provider && !(row_cache_provider == rhs.row_cache_provider))
+      return false;
+    if (__isset.key_alias != rhs.__isset.key_alias)
+      return false;
+    else if (__isset.key_alias && !(key_alias == rhs.key_alias))
+      return false;
     return true;
   }
   bool operator != (const CfDef &rhs) const {
@@ -1083,17 +1247,19 @@ class CfDef {
 };
 
 typedef struct _KsDef__isset {
-  _KsDef__isset() : strategy_options(false) {}
+  _KsDef__isset() : strategy_options(false), replication_factor(false), durable_writes(false) {}
   bool strategy_options;
+  bool replication_factor;
+  bool durable_writes;
 } _KsDef__isset;
 
 class KsDef {
  public:
 
-  static const char* ascii_fingerprint; // = "75BE67EF161D3DF7F283FF5C63C5F31A";
-  static const uint8_t binary_fingerprint[16]; // = {0x75,0xBE,0x67,0xEF,0x16,0x1D,0x3D,0xF7,0xF2,0x83,0xFF,0x5C,0x63,0xC5,0xF3,0x1A};
+  static const char* ascii_fingerprint; // = "820D5633D9CAAF0DA19926563FE0B07F";
+  static const uint8_t binary_fingerprint[16]; // = {0x82,0x0D,0x56,0x33,0xD9,0xCA,0xAF,0x0D,0xA1,0x99,0x26,0x56,0x3F,0xE0,0xB0,0x7F};
 
-  KsDef() : name(""), strategy_class(""), replication_factor(0) {
+  KsDef() : name(""), strategy_class(""), replication_factor(0), durable_writes(true) {
   }
 
   virtual ~KsDef() throw() {}
@@ -1103,6 +1269,7 @@ class KsDef {
   std::map<std::string, std::string>  strategy_options;
   int32_t replication_factor;
   std::vector<CfDef>  cf_defs;
+  bool durable_writes;
 
   _KsDef__isset __isset;
 
@@ -1116,9 +1283,15 @@ class KsDef {
       return false;
     else if (__isset.strategy_options && !(strategy_options == rhs.strategy_options))
       return false;
-    if (!(replication_factor == rhs.replication_factor))
+    if (__isset.replication_factor != rhs.__isset.replication_factor)
+      return false;
+    else if (__isset.replication_factor && !(replication_factor == rhs.replication_factor))
       return false;
     if (!(cf_defs == rhs.cf_defs))
+      return false;
+    if (__isset.durable_writes != rhs.__isset.durable_writes)
+      return false;
+    else if (__isset.durable_writes && !(durable_writes == rhs.durable_writes))
       return false;
     return true;
   }
@@ -1127,6 +1300,88 @@ class KsDef {
   }
 
   bool operator < (const KsDef & ) const;
+
+  uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
+  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
+
+};
+
+
+class CqlRow {
+ public:
+
+  static const char* ascii_fingerprint; // = "470EFC558004E98D92D604898305C04E";
+  static const uint8_t binary_fingerprint[16]; // = {0x47,0x0E,0xFC,0x55,0x80,0x04,0xE9,0x8D,0x92,0xD6,0x04,0x89,0x83,0x05,0xC0,0x4E};
+
+  CqlRow() : key("") {
+  }
+
+  virtual ~CqlRow() throw() {}
+
+  std::string key;
+  std::vector<Column>  columns;
+
+  bool operator == (const CqlRow & rhs) const
+  {
+    if (!(key == rhs.key))
+      return false;
+    if (!(columns == rhs.columns))
+      return false;
+    return true;
+  }
+  bool operator != (const CqlRow &rhs) const {
+    return !(*this == rhs);
+  }
+
+  bool operator < (const CqlRow & ) const;
+
+  uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
+  uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;
+
+};
+
+typedef struct _CqlResult__isset {
+  _CqlResult__isset() : rows(false), num(false) {}
+  bool rows;
+  bool num;
+} _CqlResult__isset;
+
+class CqlResult {
+ public:
+
+  static const char* ascii_fingerprint; // = "08BC83A60D342CCE8C03B7AB57B7570E";
+  static const uint8_t binary_fingerprint[16]; // = {0x08,0xBC,0x83,0xA6,0x0D,0x34,0x2C,0xCE,0x8C,0x03,0xB7,0xAB,0x57,0xB7,0x57,0x0E};
+
+  CqlResult() : num(0) {
+  }
+
+  virtual ~CqlResult() throw() {}
+
+  CqlResultType::type type;
+  std::vector<CqlRow>  rows;
+  int32_t num;
+
+  _CqlResult__isset __isset;
+
+  bool operator == (const CqlResult & rhs) const
+  {
+    if (!(type == rhs.type))
+      return false;
+    if (__isset.rows != rhs.__isset.rows)
+      return false;
+    else if (__isset.rows && !(rows == rhs.rows))
+      return false;
+    if (__isset.num != rhs.__isset.num)
+      return false;
+    else if (__isset.num && !(num == rhs.num))
+      return false;
+    return true;
+  }
+  bool operator != (const CqlResult &rhs) const {
+    return !(*this == rhs);
+  }
+
+  bool operator < (const CqlResult & ) const;
 
   uint32_t read(::apache::thrift::protocol::TProtocol* iprot);
   uint32_t write(::apache::thrift::protocol::TProtocol* oprot) const;


### PR DESCRIPTION
I have switched to cassandra 0.8.2 and made the changes needed to support that version. I also implemented the truncate function. At the top of my repository there's a patch which changes tr1's shared_ptr to boots'. That's something I needed, not sure if you'll find useful. The rest I think you may want to merge in.
